### PR TITLE
(maint) Add shared_origin alias for simple_config_origin

### DIFF
--- a/lib/inc/internal/path_parser.hpp
+++ b/lib/inc/internal/path_parser.hpp
@@ -18,13 +18,13 @@ namespace hocon  {
 
         static path parse_path(std::string const& path_string);
 
-        static path parse_path_expression(token_iterator& expression, simple_config_origin origin,
+        static path parse_path_expression(token_iterator& expression, shared_origin origin,
                                           std::string const& original_text = "",
                                           token_list* path_tokens = nullptr,
                                           config_syntax flavor = config_syntax::CONF);
 
         static config_node_path parse_path_node_expression(token_iterator& expression,
-                                                           simple_config_origin origin,
+                                                           shared_origin origin,
                                                            std::string const& original_text = "",
                                                            config_syntax flavor = config_syntax::CONF);
 
@@ -49,7 +49,7 @@ namespace hocon  {
 
         static path speculative_fast_parse_path(std::string const& path);
 
-        static const simple_config_origin api_origin;
+        static const shared_origin api_origin;
     };
 
 }  // namespace hocon

--- a/lib/inc/internal/simple_config_origin.hpp
+++ b/lib/inc/internal/simple_config_origin.hpp
@@ -23,7 +23,7 @@ namespace hocon {
          * Returns a pointer to a copy of this origin with the specified line number
          * as both starting and ending line.
          */
-        std::shared_ptr<simple_config_origin> with_line_number(int line_number) const;
+        std::shared_ptr<const simple_config_origin> with_line_number(int line_number) const;
 
         bool operator==(const simple_config_origin &other) const;
         bool operator!=(const simple_config_origin &other) const;
@@ -36,5 +36,7 @@ namespace hocon {
         std::string _resource_or_null;
         std::vector<std::string> _comments_or_null;
     };
+
+    using shared_origin = std::shared_ptr<const simple_config_origin>;
 
 }  // namespace hocon

--- a/lib/inc/internal/token.hpp
+++ b/lib/inc/internal/token.hpp
@@ -17,13 +17,13 @@ namespace hocon {
 
     class token {
     public:
-        token(token_type type, std::shared_ptr<simple_config_origin> origin = nullptr,
+        token(token_type type, shared_origin origin = nullptr,
               std::string token_text = "", std::string debug_string = "");
 
         virtual token_type get_token_type() const;
         virtual std::string token_text() const;
         virtual std::string to_string() const;
-        virtual std::shared_ptr<simple_config_origin> origin() const;
+        virtual shared_origin const& origin() const;
 
         int line_number() const;
 
@@ -33,7 +33,7 @@ namespace hocon {
         token_type _token_type;
 
         /** For singleton tokens this is null. */
-        std::shared_ptr<simple_config_origin> _origin;
+        shared_origin _origin;
 
         std::string _token_text;
         std::string _debug_string;

--- a/lib/inc/internal/tokenizer.hpp
+++ b/lib/inc/internal/tokenizer.hpp
@@ -22,7 +22,7 @@ namespace hocon {
 
     class token_iterator {
     public:
-        token_iterator(simple_config_origin origin, std::unique_ptr<std::istream> input, bool allow_comments);
+        token_iterator(shared_origin origin, std::unique_ptr<std::istream> input, bool allow_comments);
 
         bool has_next();
         shared_token next();
@@ -34,16 +34,12 @@ namespace hocon {
         public:
             whitespace_saver();
             void add(char c);
-            shared_token check(token_type type, simple_config_origin const& base_origin,
-                                         int line_number);
+            shared_token check(token_type type, shared_origin base_origin, int line_number);
 
         private:
-            shared_token next_is_not_simple_value(simple_config_origin const& base_origin,
-                                                            int line_number);
-            shared_token next_is_simple_value(simple_config_origin const& origin,
-                                                        int line_number);
-            shared_token create_whitespace_token(simple_config_origin const& base_origin,
-                                                           int line_number);
+            shared_token next_is_not_simple_value(shared_origin base_origin, int line_number);
+            shared_token next_is_simple_value(shared_origin origin, int line_number);
+            shared_token create_whitespace_token(shared_origin base_origin, int line_number);
 
             std::string _whitespace;
             bool _last_token_was_simple_value;
@@ -84,15 +80,14 @@ namespace hocon {
 
         static bool is_simple_value(token_type type);
         static std::string as_string(char c);
-        static std::shared_ptr<simple_config_origin> line_origin(simple_config_origin const& base_origin,
-                                                                 int line_number);
+        static shared_origin line_origin(shared_origin base_origin, int line_number);
 
-        simple_config_origin _origin;
+        shared_origin _origin;
         std::unique_ptr<std::istream> _input;
         std::vector<char> _buffer;
         bool _allow_comments;
         int _line_number;
-        std::shared_ptr<simple_config_origin> _line_origin;
+        shared_origin _line_origin;
         std::queue<shared_token> _tokens;
         whitespace_saver _whitespace_saver;
     };

--- a/lib/inc/internal/tokens.hpp
+++ b/lib/inc/internal/tokens.hpp
@@ -11,7 +11,7 @@ namespace hocon {
         value(std::unique_ptr<abstract_config_value> value, std::string original_text);
 
         std::string to_string() const override;
-        std::shared_ptr<simple_config_origin> origin() const override;
+        shared_origin const& origin() const override;
 
         shared_value get_value() const;
 
@@ -23,7 +23,7 @@ namespace hocon {
 
     class line : public token {
     public:
-        line(std::shared_ptr<simple_config_origin> origin);
+        line(shared_origin origin);
 
         std::string to_string() const override;
 
@@ -32,7 +32,7 @@ namespace hocon {
 
     class unquoted_text : public token {
     public:
-        unquoted_text(std::shared_ptr<simple_config_origin> origin, std::string text);
+        unquoted_text(shared_origin origin, std::string text);
 
         std::string to_string() const override;
 
@@ -41,7 +41,7 @@ namespace hocon {
 
     class ignored_whitespace : public token {
     public:
-        ignored_whitespace(std::shared_ptr<simple_config_origin> origin, std::string whitespace);
+        ignored_whitespace(shared_origin origin, std::string whitespace);
 
         std::string to_string() const override;
 
@@ -50,8 +50,7 @@ namespace hocon {
 
     class problem : public token {
     public:
-        problem(std::shared_ptr<simple_config_origin> origin, std::string what, std::string message,
-            bool suggest_quotes);
+        problem(shared_origin origin, std::string what, std::string message, bool suggest_quotes);
 
         std::string what() const;
         std::string message() const;
@@ -69,7 +68,7 @@ namespace hocon {
 
     class comment : public token {
     public:
-        comment(std::shared_ptr<simple_config_origin> origin, std::string text);
+        comment(shared_origin origin, std::string text);
 
         std::string text() const;
 
@@ -82,22 +81,21 @@ namespace hocon {
 
     class double_slash_comment : public comment {
     public:
-        double_slash_comment(std::shared_ptr<simple_config_origin> origin, std::string text);
+        double_slash_comment(shared_origin origin, std::string text);
 
         std::string token_text() const override;
     };
 
     class hash_comment : public comment {
     public:
-        hash_comment(std::shared_ptr<simple_config_origin> origin, std::string text);
+        hash_comment(shared_origin origin, std::string text);
 
         std::string token_text() const override;
     };
 
     class substitution : public token {
     public:
-        substitution(std::shared_ptr<simple_config_origin> origin,
-                     bool optional, token_list expression);
+        substitution(shared_origin origin, bool optional, token_list expression);
 
         bool optional() const;
         token_list const& expression() const;

--- a/lib/inc/internal/values/abstract_config_value.hpp
+++ b/lib/inc/internal/values/abstract_config_value.hpp
@@ -9,15 +9,15 @@ namespace hocon {
 
     class abstract_config_value : public config_value {
     public:
-        abstract_config_value(std::shared_ptr<simple_config_origin> origin);
+        abstract_config_value(shared_origin origin);
 
         virtual std::string transform_to_string() const;
         virtual resolved_status resolved() const;
 
-        std::shared_ptr<simple_config_origin> const& origin() const;
+        shared_origin const& origin() const;
 
     private:
-        std::shared_ptr<simple_config_origin> _origin;
+        shared_origin _origin;
     };
 
     using shared_value = std::shared_ptr<const abstract_config_value>;

--- a/lib/inc/internal/values/config_boolean.hpp
+++ b/lib/inc/internal/values/config_boolean.hpp
@@ -6,7 +6,7 @@ namespace hocon {
 
     class config_boolean : public abstract_config_value {
     public:
-        config_boolean(std::shared_ptr<simple_config_origin> origin, bool value);
+        config_boolean(shared_origin origin, bool value);
 
         config_value_type value_type() const override;
         std::string transform_to_string() const override;

--- a/lib/inc/internal/values/config_double.hpp
+++ b/lib/inc/internal/values/config_double.hpp
@@ -9,8 +9,7 @@ namespace hocon {
 
     class config_double : public config_number {
     public:
-        config_double(std::shared_ptr<simple_config_origin> origin,
-                      double value, std::string original_text);
+        config_double(shared_origin origin, double value, std::string original_text);
 
         std::string transform_to_string() const override;
 

--- a/lib/inc/internal/values/config_int.hpp
+++ b/lib/inc/internal/values/config_int.hpp
@@ -6,8 +6,7 @@ namespace hocon {
 
     class config_int : public config_number {
     public:
-        config_int(std::shared_ptr<simple_config_origin> origin,
-                    int value, std::string original_text);
+        config_int(shared_origin origin, int value, std::string original_text);
 
         std::string transform_to_string() const override;
 

--- a/lib/inc/internal/values/config_long.hpp
+++ b/lib/inc/internal/values/config_long.hpp
@@ -9,8 +9,7 @@ namespace hocon {
 
     class config_long : public config_number {
     public:
-        config_long(std::shared_ptr<simple_config_origin> origin,
-                    int64_t value, std::string original_text);
+        config_long(shared_origin origin, int64_t value, std::string original_text);
 
         std::string transform_to_string() const override;
 

--- a/lib/inc/internal/values/config_null.hpp
+++ b/lib/inc/internal/values/config_null.hpp
@@ -16,7 +16,7 @@ namespace hocon {
      */
     class config_null : public abstract_config_value {
     public:
-        config_null(std::shared_ptr<simple_config_origin> origin);
+        config_null(shared_origin origin);
 
         config_value_type value_type() const override;
         std::string transform_to_string() const override;

--- a/lib/inc/internal/values/config_number.hpp
+++ b/lib/inc/internal/values/config_number.hpp
@@ -9,7 +9,7 @@ namespace hocon {
 
     class config_number : public abstract_config_value {
     public:
-        config_number(std::shared_ptr<simple_config_origin> origin,
+        config_number(shared_origin origin,
                       std::string original_text);
 
         std::string transform_to_string() const;
@@ -25,10 +25,10 @@ namespace hocon {
         int int_value_range_checked(std::string const& path);
 
         static std::unique_ptr<config_number> new_number(
-                std::shared_ptr<simple_config_origin> origin, int64_t value, std::string original_text);
+                shared_origin origin, int64_t value, std::string original_text);
 
         static std::unique_ptr<config_number> new_number(
-                std::shared_ptr<simple_config_origin> origin, double value, std::string original_text);
+                shared_origin origin, double value, std::string original_text);
 
     private:
         std::string _original_text;

--- a/lib/inc/internal/values/config_string.hpp
+++ b/lib/inc/internal/values/config_string.hpp
@@ -8,7 +8,7 @@ namespace hocon {
 
     class config_string : public abstract_config_value {
     public:
-        config_string(std::shared_ptr<simple_config_origin> origin, std::string text, config_string_type quoted);
+        config_string(shared_origin origin, std::string text, config_string_type quoted);
 
         config_value_type value_type() const override;
         std::string transform_to_string() const override;

--- a/lib/src/path_parser.cc
+++ b/lib/src/path_parser.cc
@@ -19,7 +19,7 @@ namespace hocon {
     }
 
     /** Path parser */
-    const simple_config_origin path_parser::api_origin = simple_config_origin("path parameter");
+    const shared_origin path_parser::api_origin = make_shared<simple_config_origin>("path parameter");
 
     config_node_path path_parser::parse_path_node(string const& path_string, config_syntax flavor) {
         token_iterator tokens = token_iterator(api_origin,
@@ -44,7 +44,7 @@ namespace hocon {
     }
 
     config_node_path path_parser::parse_path_node_expression(token_iterator& expression,
-                                                             simple_config_origin origin,
+                                                             shared_origin origin,
                                                              string const& original_text,
                                                              config_syntax flavor)
     {
@@ -53,7 +53,7 @@ namespace hocon {
         return config_node_path(path, tokens);
     }
 
-    path path_parser::parse_path_expression(token_iterator& expression, simple_config_origin origin,
+    path path_parser::parse_path_expression(token_iterator& expression, shared_origin origin,
                                             string const& original_text, token_list* path_tokens,
                                             config_syntax flavor)
     {

--- a/lib/src/simple_config_origin.cc
+++ b/lib/src/simple_config_origin.cc
@@ -29,7 +29,7 @@ namespace hocon {
         return _line_number;
     }
 
-    shared_ptr<simple_config_origin> simple_config_origin::with_line_number(int line_number) const {
+    shared_origin simple_config_origin::with_line_number(int line_number) const {
         return make_shared<simple_config_origin>(_description, line_number, line_number, _origin_type,
                     _resource_or_null, _comments_or_null);
     }

--- a/lib/src/token.cc
+++ b/lib/src/token.cc
@@ -8,7 +8,7 @@ namespace hocon {
     unsupported_exception::unsupported_exception(string const& message) :
         runtime_error(message) { }
 
-    token::token(token_type type, shared_ptr<simple_config_origin> origin, string token_text, string debug_string) :
+    token::token(token_type type, shared_origin origin, string token_text, string debug_string) :
         _token_type(type), _origin(move(origin)), _token_text(move(token_text)),
         _debug_string(move(debug_string)) { }
 
@@ -33,7 +33,7 @@ namespace hocon {
         }
     }
 
-    shared_ptr<simple_config_origin> token::origin() const {
+    shared_origin const& token::origin() const {
         if (_origin) {
             return _origin;
         } else {

--- a/lib/src/tokens.cc
+++ b/lib/src/tokens.cc
@@ -19,7 +19,7 @@ namespace hocon {
         return _value->transform_to_string();
     }
 
-    shared_ptr<simple_config_origin> value::origin() const {
+    shared_origin const& value::origin() const {
         return _value->origin();
     }
 
@@ -33,7 +33,7 @@ namespace hocon {
     }
 
     /** Line token */
-    line::line(shared_ptr<simple_config_origin> origin) :
+    line::line(shared_origin origin) :
             token(token_type::NEWLINE, move(origin), "\n") { }
 
     string line::to_string() const {
@@ -45,7 +45,7 @@ namespace hocon {
     }
 
     /** Unquoted text token */
-    unquoted_text::unquoted_text(shared_ptr<simple_config_origin> origin, string text) :
+    unquoted_text::unquoted_text(shared_origin origin, string text) :
             token(token_type::UNQUOTED_TEXT, move(origin), move(text)) { }
 
     string unquoted_text::to_string() const {
@@ -58,7 +58,7 @@ namespace hocon {
     }
 
     /** Ignored whitespace token */
-    ignored_whitespace::ignored_whitespace(shared_ptr<simple_config_origin> origin, string whitespace) :
+    ignored_whitespace::ignored_whitespace(shared_origin origin, string whitespace) :
         token(token_type::IGNORED_WHITESPACE, move(origin), move(whitespace)) { }
 
     string ignored_whitespace::to_string() const {
@@ -71,7 +71,7 @@ namespace hocon {
     }
 
     /** Problem token */
-    problem::problem(shared_ptr<simple_config_origin> origin, string what, string message,
+    problem::problem(shared_origin origin, string what, string message,
         bool suggest_quotes) : token(token_type::PROBLEM, move(origin)), _what(move(what)),
         _message(move(message)), _suggest_quotes(suggest_quotes) { }
 
@@ -103,7 +103,7 @@ namespace hocon {
     }
 
     /** Comment token */
-    comment::comment(shared_ptr<simple_config_origin> origin, string text) :
+    comment::comment(shared_origin origin, string text) :
         token(token_type::COMMENT, move(origin)), _text(move(text)) { }
 
     string comment::text() const {
@@ -119,7 +119,7 @@ namespace hocon {
     }
 
     /** Double-slash comment token */
-    double_slash_comment::double_slash_comment(shared_ptr<simple_config_origin> origin, string text) :
+    double_slash_comment::double_slash_comment(shared_origin origin, string text) :
         comment(move(origin), move(text)) { }
 
     string double_slash_comment::token_text() const {
@@ -127,7 +127,7 @@ namespace hocon {
     }
 
     /** Hash comment token */
-    hash_comment::hash_comment(shared_ptr<simple_config_origin> origin, string text) :
+    hash_comment::hash_comment(shared_origin origin, string text) :
         comment(move(origin), move(text)) { }
 
     string hash_comment::token_text() const {
@@ -135,7 +135,7 @@ namespace hocon {
     }
 
     /** Substitution token */
-    substitution::substitution(shared_ptr<simple_config_origin> origin, bool optional,
+    substitution::substitution(shared_origin origin, bool optional,
         token_list expression) : token(token_type::SUBSTITUTION, move(origin)), _optional(optional),
         _expression(move(expression)) { }
 

--- a/lib/src/values/abstract_config_value.cc
+++ b/lib/src/values/abstract_config_value.cc
@@ -4,14 +4,14 @@ using namespace std;
 
 namespace hocon {
 
-    abstract_config_value::abstract_config_value(shared_ptr<simple_config_origin> origin) :
+    abstract_config_value::abstract_config_value(shared_origin origin) :
         _origin(move(origin)) { }
 
     string abstract_config_value::transform_to_string() const {
         return "";
     }
 
-    shared_ptr<simple_config_origin> const& abstract_config_value::origin() const {
+    shared_origin const& abstract_config_value::origin() const {
         return _origin;
     }
 

--- a/lib/src/values/config_boolean.cc
+++ b/lib/src/values/config_boolean.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_boolean::config_boolean(shared_ptr<simple_config_origin> origin, bool value) :
+    config_boolean::config_boolean(shared_origin origin, bool value) :
         abstract_config_value(move(origin)), _value(value) { }
 
     config_value_type config_boolean::value_type() const {

--- a/lib/src/values/config_double.cc
+++ b/lib/src/values/config_double.cc
@@ -4,8 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_double::config_double(shared_ptr<simple_config_origin> origin,
-                                 double value, string original_text) :
+    config_double::config_double(shared_origin origin, double value, string original_text) :
             config_number(move(origin), move(original_text)), _value(value) { }
 
     std::string config_double::transform_to_string() const {

--- a/lib/src/values/config_int.cc
+++ b/lib/src/values/config_int.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_int::config_int(shared_ptr<simple_config_origin> origin, int value, string original_text) :
+    config_int::config_int(shared_origin origin, int value, string original_text) :
             config_number(move(origin), move(original_text)), _value(value) { }
 
     std::string config_int::transform_to_string() const {

--- a/lib/src/values/config_long.cc
+++ b/lib/src/values/config_long.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_long::config_long(shared_ptr<simple_config_origin> origin, int64_t value, string original_text) :
+    config_long::config_long(shared_origin origin, int64_t value, string original_text) :
             config_number(move(origin), move(original_text)), _value(value) { }
 
     std::string config_long::transform_to_string() const {

--- a/lib/src/values/config_null.cc
+++ b/lib/src/values/config_null.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_null::config_null(shared_ptr<simple_config_origin> origin) :
+    config_null::config_null(shared_origin origin) :
             abstract_config_value(move(origin)) { }
 
     config_value_type config_null::value_type() const {

--- a/lib/src/values/config_number.cc
+++ b/lib/src/values/config_number.cc
@@ -9,8 +9,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_number::config_number(shared_ptr<simple_config_origin> origin,
-                                 string original_text) :
+    config_number::config_number(shared_origin origin, string original_text) :
             abstract_config_value(move(origin)), _original_text(move(original_text)) { }
 
     config_value_type config_number::value_type() const {
@@ -47,7 +46,7 @@ namespace hocon {
     }
 
     unique_ptr<config_number> config_number::new_number(
-            shared_ptr<simple_config_origin> origin, int64_t value, std::string original_text) {
+            shared_origin origin, int64_t value, std::string original_text) {
         if (value >= numeric_limits<int>::min() && value <= numeric_limits<int>::max()) {
             return unique_ptr<config_int>(new config_int(move(origin), static_cast<int>(value),
                                                          move(original_text)));
@@ -57,7 +56,7 @@ namespace hocon {
     }
 
     unique_ptr<config_number> config_number::new_number(
-            shared_ptr<simple_config_origin> origin, double value, std::string original_text) {
+            shared_origin origin, double value, std::string original_text) {
         int64_t as_long = static_cast<int64_t>(value);
         if (as_long == value) {
             return new_number(move(origin), as_long, move(original_text));

--- a/lib/src/values/config_string.cc
+++ b/lib/src/values/config_string.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    config_string::config_string(shared_ptr<simple_config_origin> origin, string text, config_string_type quoted) :
+    config_string::config_string(shared_origin origin, string text, config_string_type quoted) :
         abstract_config_value(move(origin)), _text(move(text)), _quoted(quoted) { }
 
     config_value_type config_string::value_type() const {

--- a/lib/tests/test_utils.cc
+++ b/lib/tests/test_utils.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace hocon {
 
-    shared_ptr<simple_config_origin> fake_origin(string description, int line_number) {
+    shared_origin fake_origin(string description, int line_number) {
         return make_shared<simple_config_origin>(move(description), line_number, line_number, origin_type::GENERIC);
     }
 

--- a/lib/tests/test_utils.hpp
+++ b/lib/tests/test_utils.hpp
@@ -16,11 +16,10 @@
 
 namespace hocon {
 
-    std::shared_ptr<simple_config_origin> fake_origin(std::string description = "fake", int line_number = 0);
+    shared_origin fake_origin(std::string description = "fake", int line_number = 0);
 
     /** Tokens */
-    std::shared_ptr<value> string_token(std::string text,
-                                        config_string_type type = config_string_type::QUOTED);
+    std::shared_ptr<value> string_token(std::string text, config_string_type type = config_string_type::QUOTED);
 
     std::shared_ptr<value> bool_token(bool boolean);
 

--- a/lib/tests/tokenizer_test.cc
+++ b/lib/tests/tokenizer_test.cc
@@ -7,7 +7,7 @@ using namespace std;
 using namespace hocon;
 
 token_list tokenize_as_list(string const& source) {
-    token_iterator iter(*fake_origin(), unique_ptr<istringstream>(new istringstream(source)), true);
+    token_iterator iter(fake_origin(), unique_ptr<istringstream>(new istringstream(source)), true);
     // get all the tokens from the string and put them in a vector
     token_list tokens;
     while (iter.has_next()) {
@@ -641,7 +641,7 @@ TEST_CASE("brackets and braces", "[tokenizer]") {
 }
 
 void test_for_config_error(string source) {
-    token_iterator iter(*fake_origin(), unique_ptr<istringstream>(new istringstream(source)), true);
+    token_iterator iter(fake_origin(), unique_ptr<istringstream>(new istringstream(source)), true);
     while (iter.has_next()) {
         iter.next();
     }


### PR DESCRIPTION
A few uses of simple_config_origin showed bad practices of creating a
new shared_ptr of a simple_config_origin from a reference drawn from
another shared_ptr. This can lead to freed memory references. The
shared pointers also didn't use const, allowing for the shared versions
of simple_config_origin to be modified.

Change to passing shared_ptr<const simple_config_origin> everywhere,
and add an alias shared_origin to make that simpler.