### PR TITLE
(HC-22) Port ConfigParseOptions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,6 +36,7 @@ set(PROJECT_SOURCES
     src/tokenizer.cc
     src/simple_config_origin.cc
     src/config_util.cc
+    src/config_parse_options.cc
 )
 
 ## An object target is generated that can be used by both the library and test executable targets.

--- a/lib/inc/hocon/config_includer.hpp
+++ b/lib/inc/hocon/config_includer.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+#include <memory>
+
+namespace hocon {
+    /**
+     * Implement this interface and provide an instance to
+     * {@link config_parse_options#set_includer config_parse_options.set_includer()} to
+     * customize handling of {@code include} statements in config files. You may
+     * also want to implement {@link config_includer_file} and {@link config_includer_URL}, or not.
+     */
+    class config_includer {
+    public:
+        /**
+         * Returns a new includer that falls back to the given includer. This is how
+         * you can obtain the default includer; it will be provided as a fallback.
+         * It's up to your includer to chain to it if you want to. You might want to
+         * merge any files found by the fallback includer with any objects you load
+         * yourself.
+         *
+         * It's important to handle the case where you already have the fallback
+         * with a "return this", i.e. this method should not create a new object if
+         * the fallback is the same one you already have. The same fallback may be
+         * added repeatedly.
+         *
+         * @param fallback the previous includer for chaining
+         * @return a new includer
+         */
+        virtual std::shared_ptr<config_includer> with_fallback(std::shared_ptr<config_includer> fallback) const = 0;
+
+        /**
+         * Parses another item to be included. The returned object typically would
+         * not have substitutions resolved. You can throw a config_exception here to
+         * abort parsing, or return an empty object, but may not return null.
+         * 
+         * This method is used for a "heuristic" include statement that does not
+         * specify file, or URL resource. If the include statement does
+         * specify, then the same class implementing {@link config_includer} must
+         * also implement {@link config_includer_file} or {@link config_includer_URL} as needed, or a
+         * default includer will be used.
+         * 
+         * @param context
+         *            some info about the include context
+         * @param what
+         *            the include statement's argument
+         * @return a non-null config_object
+         */
+        // TODO: Implement config_include_context, config_object
+        // virtual config_object include(shared_ptr<config_include_context> context, shared_ptr<std::string> what) const = 0;
+    };
+}  // namespace hocon

--- a/lib/inc/hocon/config_parse_options.hpp
+++ b/lib/inc/hocon/config_parse_options.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include "config_syntax.hpp"
+
+namespace hocon {
+    class config_includer;
+
+    /**
+     * A set of options related to parsing.
+     *
+     * <p>
+     * This object is immutable, so the "setters" returns a new object.
+     *
+     * <p>
+     * Here is an example of creating a custom {@code config_parse_options}:
+     *
+     * <pre>
+     *     config_parse_options options = config_parse_options.defaults()
+     *         .set_syntax(config_syntax.JSON)
+     *         .set_allow_missing(false)
+     * </pre>
+     *
+     * ClassLoader is Java-specific, so it was not ported to C++.
+     */
+    class config_parse_options {
+    public:
+        /**
+         * Gets an instance of <code>config_parse_options</code> with all fields
+         * set to the default values. Start with this instance and make any
+         * changes you need.
+         * @return the default parse options
+         */
+        config_parse_options();
+
+        /**
+         * Set the file format. If set to null, try to guess from any available
+         * filename extension; if guessing fails, assume {@link config_syntax#CONF}.
+         *
+         * @param syntax
+         *            a syntax or {@code nullptr} for best guess
+         * @return options with the syntax set
+         */
+        config_parse_options set_syntax(config_syntax syntax) const;
+
+        /**
+         * Gets the current syntax option, which may be null for "any".
+         * @return the current syntax or nullptr
+         */
+        config_syntax const& get_syntax() const;
+
+        /**
+         * Set a description for the thing being parsed. In most cases this will be
+         * set up for you to something like the filename, but if you provide just an
+         * input stream you might want to improve on it. Set to null to allow the
+         * library to come up with something automatically. This description is the
+         * basis for the {@link config_origin} of the parsed values.
+         *
+         * @param origin_description description to put in the {@link config_origin}
+         * @return options with the origin description set
+         */
+        config_parse_options set_origin_description(std::shared_ptr<std::string> origin_description) const;
+
+        /**
+         * Gets the current origin description, which may be null for "automatic".
+         * @return the current origin description or null
+         */
+        std::shared_ptr<std::string> const& get_origin_description() const;
+
+        /**
+         * Set to false to throw an exception if the item being parsed (for example
+         * a file) is missing. Set to true to just return an empty document in that
+         * case.
+         *
+         * @param allow_missing true to silently ignore missing item
+         * @return options with the "allow missing" flag set
+         */
+        config_parse_options set_allow_missing(bool allow_missing) const;
+
+        /**
+         * Gets the current "allow missing" flag.
+         * @return whether we allow missing files
+         */
+        bool get_allow_missing() const;
+
+        /**
+         * Set a {@link config_includer} which customizes how includes are handled.
+         * null means to use the default includer.
+         *
+         * @param includer the includer to use or null for default
+         * @return new version of the parse options with different includer
+         */
+        config_parse_options set_includer(std::shared_ptr<config_includer> includer) const;
+
+        /**
+         * Prepends a {@link config_includer} which customizes how
+         * includes are handled.  To prepend your includer, the
+         * library calls {@link config_includer#with_fallback} on your
+         * includer to append the existing includer to it.
+         *
+         * @param includer the includer to prepend (may not be null)
+         * @return new version of the parse options with different includer
+         */
+        config_parse_options prepend_includer(std::shared_ptr<config_includer> includer) const;
+
+        /**
+         * Appends a {@link config_includer} which customizes how
+         * includes are handled.  To append, the library calls {@link
+         * config_includer#with_fallback} on the existing includer.
+         *
+         * @param includer the includer to append (may not be null)
+         * @return new version of the parse options with different includer
+         */
+        config_parse_options append_includer(std::shared_ptr<config_includer> includer) const;
+
+        /**
+         * Gets the current includer (will be null for the default includer).
+         * @return current includer or null
+         */
+        std::shared_ptr<config_includer> const& get_includer() const;
+
+    private:
+        config_parse_options(config_syntax syntax, std::shared_ptr<std::string> origin_desc,
+                bool allow_missing, std::shared_ptr<config_includer> includer);
+        config_parse_options with_fallback_origin_description(std::shared_ptr<std::string> origin_description) const;
+
+        config_syntax _syntax;
+        std::shared_ptr<std::string> _origin_description;
+        bool _allow_missing;
+        std::shared_ptr<config_includer> _includer;
+    };
+}  // namespace hocon

--- a/lib/src/config_parse_options.cc
+++ b/lib/src/config_parse_options.cc
@@ -1,0 +1,93 @@
+#include <hocon/config_parse_options.hpp>
+#include <hocon/config_includer.hpp>
+
+using namespace std;
+
+namespace hocon {
+
+    config_parse_options::config_parse_options(config_syntax syntax, shared_ptr<string> origin_desc,
+            bool allow_missing, shared_ptr<config_includer> includer) :
+        _syntax(syntax), _origin_description(move(origin_desc)),
+        _allow_missing(allow_missing), _includer(move(includer)) {}
+
+    config_parse_options::config_parse_options(): config_parse_options(config_syntax::CONF, nullptr, true, nullptr) {}
+
+    config_parse_options config_parse_options::set_syntax(config_syntax syntax) const
+    {
+        return config_parse_options{syntax, _origin_description, _allow_missing, _includer};
+    }
+
+    config_syntax const& config_parse_options::get_syntax() const
+    {
+        return _syntax;
+    }
+
+    config_parse_options config_parse_options::set_origin_description(shared_ptr<string> origin_description) const
+    {
+        return config_parse_options{_syntax, move(origin_description), _allow_missing, _includer};
+    }
+
+
+    shared_ptr<string> const& config_parse_options::get_origin_description() const
+    {
+        return _origin_description;
+    }
+
+    config_parse_options config_parse_options::with_fallback_origin_description(shared_ptr<string> origin_description) const
+    {
+        if (!_origin_description) {
+            return set_origin_description(origin_description);
+        } else {
+            return *this;
+        }
+    }
+
+    config_parse_options config_parse_options::set_allow_missing(bool allow_missing) const
+    {
+        return config_parse_options{_syntax, _origin_description, allow_missing, _includer};
+    }
+
+    bool config_parse_options::get_allow_missing() const
+    {
+        return _allow_missing;
+    }
+
+    config_parse_options config_parse_options::set_includer(shared_ptr<config_includer> includer) const
+    {
+        return config_parse_options{_syntax, _origin_description, _allow_missing, move(includer)};
+    }
+
+    config_parse_options config_parse_options::prepend_includer(shared_ptr<config_includer> includer) const
+    {
+        if (!includer) {
+            throw runtime_error("null includer passed to prepend_includer");
+        }
+        if (_includer == includer) {
+            return *this;
+        } else if (_includer) {
+            return set_includer(includer->with_fallback(_includer));
+        } else {
+            return set_includer(includer);
+        }
+    }
+
+    config_parse_options config_parse_options::append_includer(shared_ptr<config_includer> includer) const
+    {
+        if (!includer) {
+            throw runtime_error("null includer passed to append_includer");
+        }
+        if (_includer == includer) {
+            return *this;
+        } else if (_includer) {
+            return set_includer(_includer->with_fallback(move(includer)));
+        } else {
+            return set_includer(includer);
+        }
+    }
+
+    shared_ptr<config_includer> const& config_parse_options::get_includer() const
+    {
+        return _includer;
+    }
+
+}  // namespace hocon


### PR DESCRIPTION
For now we leave config_includer unimplemented, as it's not being
exercised.

config_parse_options was kept an immutable object because we already
wanted to use a shared_ptr for config_includer, to avoid having to make
it a concrete class, and it keeps the implementation more in-line with
the original.

Copies should be light-weight, but we may reconsider and make this a
mutable class to avoid lots of copies if it's never really shared.