### PR TITLE
(HC-40) Port parseable_not_found and relative_name_source classes

### DIFF
--- a/lib/inc/internal/parseable.hpp
+++ b/lib/inc/internal/parseable.hpp
@@ -10,11 +10,14 @@ namespace hocon {
 
     class parseable_file;
     class parseable_string;
+    class parseable_not_found;
 
     class parseable : public config_parseable, public std::enable_shared_from_this<parseable> {
     public:
         static parseable_file new_file(std::string input_file_path, shared_parse_options options);
         static parseable_string new_string(std::string s, shared_parse_options options);
+        static parseable_not_found new_not_found(std::string what_not_found, std::string message,
+                                                 shared_parse_options options);
 
         static config_syntax syntax_from_extension(std::string name);
 
@@ -87,6 +90,20 @@ namespace hocon {
 
     private:
         std::string _resource;
+    };
+
+    // this is a parseable that doesn't exist and just throws when you try to
+    // parse it
+    class parseable_not_found : public parseable {
+    public:
+        parseable_not_found(std::string what, std::string message, shared_parse_options options);
+
+        std::unique_ptr<std::istream> reader() override;
+        shared_origin create_origin() override;
+
+    private:
+        std::string _what;
+        std::string _message;
     };
 
 }  // namespace hocon

--- a/lib/inc/internal/simple_includer.hpp
+++ b/lib/inc/internal/simple_includer.hpp
@@ -19,4 +19,20 @@ namespace hocon {
         std::shared_ptr<config_includer> _fallback;
     };
 
+    class name_source {
+    public:
+        virtual std::shared_ptr<config_parseable> name_to_parseable(std::string name,
+                                                                    shared_parse_options parse_options) const = 0;
+    };
+
+    class relative_name_source : public name_source {
+    public:
+        relative_name_source(std::shared_ptr<config_include_context> context);
+
+        std::shared_ptr<config_parseable> name_to_parseable(std::string name,
+                                                            shared_parse_options parse_options) const override;
+    private:
+        const std::shared_ptr<config_include_context> _context;
+    };
+
 }  // namespace hocon

--- a/lib/src/parseable.cc
+++ b/lib/src/parseable.cc
@@ -21,6 +21,11 @@ namespace hocon {
         return parseable_string(move(s), move(options));
     }
 
+    parseable_not_found parseable::new_not_found(std::string what_not_found, std::string message,
+                                                 shared_parse_options options) {
+        return parseable_not_found(move(what_not_found), move(message), move(options));
+    }
+
     void parseable::post_construct(shared_parse_options base_options) {
         _initial_options = fixup_options(base_options);
 
@@ -228,5 +233,19 @@ namespace hocon {
 
     shared_origin parseable_resources::create_origin() {
         return make_shared<simple_config_origin>(_resource);
+    }
+
+    /** Parseable Not Found */
+    parseable_not_found::parseable_not_found(std::string what, std::string message, shared_parse_options options) :
+            _what(move(what)), _message(move(message)) {
+        post_construct(options);
+    }
+
+    std::unique_ptr<std::istream> parseable_not_found::reader() {
+        throw config_exception(_message);
+    }
+
+    shared_origin parseable_not_found::create_origin() {
+        return make_shared<simple_config_origin>(_what);
     }
 }  // namespace hocon

--- a/lib/src/simple_includer.cc
+++ b/lib/src/simple_includer.cc
@@ -1,4 +1,5 @@
 #include <internal/simple_includer.hpp>
+#include <internal/parseable.hpp>
 
 using namespace std;
 
@@ -8,6 +9,23 @@ namespace hocon {
         // the class loader and includer are inherited, but not this other stuff
         return options->set_syntax(config_syntax::UNSPECIFIED)
                 .set_origin_description(make_shared<string>("")).set_allow_missing(true);
+    }
+
+    /** Relative name source */
+    relative_name_source::relative_name_source(shared_ptr<config_include_context> context) :
+            _context(move(context)) {}
+
+    shared_ptr<config_parseable> relative_name_source::name_to_parseable(string name,
+                                                                         shared_parse_options parse_options) const {
+        auto p = _context->relative_to(name);
+        if (p == nullptr) {
+            // avoid returning null
+            return make_shared<parseable_not_found>(parseable::new_not_found(name,
+                                                                             "include was not found: '" + name + "'",
+                                                                             parse_options));
+        } else {
+            return p;
+        }
     }
 
 }  // namespace hocon


### PR DESCRIPTION
These classes are needed by the simple_includer class. Bring in
ParseableNotFound, the NameSource interface and RelativeNameSource.