### PR TITLE
(HC-10) Port Unmergeable interface and SubstitutionExpression class

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,6 +60,7 @@ set(PROJECT_SOURCES
     src/config_resolve_options.cc
     src/config.cc
     src/default_transformer.cc
+    src/substitution_expression.cc
 )
 
 ## An object target is generated that can be used by both the library and test executable targets.

--- a/lib/inc/internal/substitution_expression.hpp
+++ b/lib/inc/internal/substitution_expression.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <memory>
+
+namespace hocon {
+
+    class substitution_expression : public std::enable_shared_from_this<substitution_expression> {
+    public:
+        substitution_expression(std::string path, bool optional);
+
+        std::string path() const;
+        bool optional() const;
+
+        std::shared_ptr<substitution_expression> change_path(std::string new_path);
+
+        std::string to_string() const;
+
+    private:
+        const std::string _path;
+        const bool _optional;
+    };
+
+}  // namespace hocon
+

--- a/lib/inc/internal/unmergeable.hpp
+++ b/lib/inc/internal/unmergeable.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <hocon/config_value.hpp>
+#include <vector>
+
+namespace hocon {
+
+    /**
+    * Interface that tags a ConfigValue that is not mergeable until after
+    * substitutions are resolved. Basically these are special ConfigValue that
+    * never appear in a resolved tree, like {@link ConfigSubstitution} and
+    * {@link ConfigDelayedMerge}.
+    */
+    class unmergeable {
+    public:
+        virtual std::vector<shared_value> unmerged_values() const = 0;
+    };
+
+}  // namespace hocon
+

--- a/lib/src/substitution_expression.cc
+++ b/lib/src/substitution_expression.cc
@@ -1,0 +1,31 @@
+#include <internal/substitution_expression.hpp>
+
+using namespace std;
+
+namespace hocon {
+
+    substitution_expression::substitution_expression(string path, bool optional) :
+        _path(move(path)), _optional(move(optional)) { }
+
+    string substitution_expression::path() const {
+        return _path;
+    }
+
+    bool substitution_expression::optional() const {
+        return _optional;
+    }
+
+    shared_ptr<substitution_expression> substitution_expression::change_path(std::string new_path) {
+        if (new_path == _path) {
+            return shared_from_this();
+        } else {
+            return make_shared<substitution_expression>(move(new_path), _optional);
+        }
+    }
+
+    string substitution_expression::to_string() const {
+        return string("${") + (_optional ? "?" : "") + _path + "}";
+    }
+
+}  // namespace hocon
+


### PR DESCRIPTION
The first of these commits ports the small Unmergeable interface, which is needed by several other classes down the road.

The second commit ports the SubstitutionExpression class, which is needed by the ConfigReference implementation.

I'm putting this up now rather than waiting until all of ConfigReference is done both to make review more digestible and get quicker feedback on any insanity in this code before I get too deep.