### PR TITLE
(maint) Fixup issues with partial ConfigParser implementation

### DIFF
--- a/lib/inc/internal/config_parser.hpp
+++ b/lib/inc/internal/config_parser.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <hocon/config_value.hpp>
 #include <hocon/config_syntax.hpp>
 #include <hocon/config_include_context.hpp>
 #include <hocon/config_parse_options.hpp>
-#include <internal/path.hpp>
+#include <hocon/path.hpp>
 #include <internal/nodes/config_node_root.hpp>
 #include <internal/nodes/abstract_config_node_value.hpp>
-#include <internal/values/abstract_config_value.hpp>
 #include <memory>
 #include <stack>
 #include <vector>

--- a/lib/src/simple_config_origin.cc
+++ b/lib/src/simple_config_origin.cc
@@ -42,7 +42,7 @@ namespace hocon {
         }
     }
 
-    shared_origin simple_config_origin::append_comments(vector<string> comments) const {
+    shared_ptr<const simple_config_origin> simple_config_origin::append_comments(vector<string> comments) const {
         if (comments == _comments_or_null || comments.empty()) {
             return shared_from_this();
         } else {


### PR DESCRIPTION
This commit changes the definition of simple_config_origin::append_comments
to match its declaration. In addition, several erroneous #include paths
have been fixed in the config_parser header.