### PR TITLE
(maint) Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Optionally, also prepare the debug environment:
 
 ## Testing
 
-Run tests with `make tests`.
+Run tests with `make test`.


### PR DESCRIPTION
Change `make tests` to `make test`.