### PR TITLE
[WIP] (HC-39) Port header files for SimpleConfigList

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,7 @@ set(PROJECT_SOURCES
     src/config.cc
     src/default_transformer.cc
     src/substitution_expression.cc
+    src/simple_config_list.cc
 )
 
 ## An object target is generated that can be used by both the library and test executable targets.

--- a/lib/inc/hocon/config_list.hpp
+++ b/lib/inc/hocon/config_list.hpp
@@ -36,6 +36,8 @@ namespace hocon {
 
     class config_list : public config_value {
     public:
+        config_list(shared_origin origin) : config_value(move(origin)) {}
+
         virtual std::shared_ptr<const config_list> with_origin(shared_origin origin) = 0;
     };
 }

--- a/lib/inc/hocon/config_list.hpp
+++ b/lib/inc/hocon/config_list.hpp
@@ -37,6 +37,5 @@ namespace hocon {
     class config_list : public config_value {
     public:
         virtual std::shared_ptr<const config_list> with_origin(shared_origin origin) = 0;
-
     };
 }

--- a/lib/inc/hocon/config_list.hpp
+++ b/lib/inc/hocon/config_list.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "config_value.hpp"
+#include "config_origin.hpp"
+#include <vector>
+
+namespace hocon {
+
+    /**
+     * Subtype of {@link ConfigValue} representing a list value, as in JSON's
+     * {@code [1,2,3]} syntax.
+     *
+     * <p>
+     * {@code ConfigList} implements {@code java.util.List<ConfigValue>} so you can
+     * use it like a regular Java list. Or call {@link #unwrapped()} to unwrap the
+     * list elements into plain Java values.
+     *
+     * <p>
+     * Like all {@link ConfigValue} subtypes, {@code ConfigList} is immutable. This
+     * makes it threadsafe and you never have to create "defensive copies." The
+     * mutator methods from {@link java.util.List} all throw
+     * {@link java.lang.UnsupportedOperationException}.
+     *
+     * <p>
+     * The {@link ConfigValue#valueType} method on a list returns
+     * {@link ConfigValueType#LIST}.
+     * 
+     * <p>
+     * <em>Do not implement {@code ConfigList}</em>; it should only be implemented
+     * by the config library. Arbitrary implementations will not work because the
+     * library internals assume a specific concrete implementation. Also, this
+     * interface is likely to grow new methods over time, so third-party
+     * implementations will break.
+     * 
+     */
+
+    class config_list : public config_value {
+    public:
+        virtual std::shared_ptr<const config_list> with_origin(shared_origin origin) = 0;
+
+    };
+}

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -129,11 +129,13 @@ namespace hocon {
          */
         shared_value relativized(std::string prefix) const { return shared_from_this(); }
 
+        virtual resolve_status get_resolve_status() const;
+
+        friend resolve_status resolve_status_from_values(std::vector<shared_value> v);
     protected:
         config_value(shared_origin origin);
 
         virtual std::string transform_to_string() const;
-        virtual resolve_status get_resolve_status() const;
         void render(std::string& result, int indent, bool at_root, std::string at_key,
                     config_render_options options) const;
         virtual void render(std::string& result, int indent, bool at_root, config_render_options options) const;

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -114,7 +114,7 @@ namespace hocon {
          *         path.
          */
         shared_config at_path(std::string const& path_expression) const;
-        
+
         /**
          * This is used when including one file in another; the included file is
          * relativized to the path it's included into in the parent file. The point
@@ -155,10 +155,8 @@ namespace hocon {
         private:
             std::string _prefix;
         };
+
     private:
         shared_origin _origin;
     };
-    
-    
-
 }  // namespace hocon

--- a/lib/inc/internal/container.hpp
+++ b/lib/inc/internal/container.hpp
@@ -24,5 +24,5 @@ namespace hocon {
          */
         virtual bool has_descendant(shared_value descendant) const = 0;
     };
-} //namespace hocon
 
+}  // namespace hocon

--- a/lib/inc/internal/container.hpp
+++ b/lib/inc/internal/container.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <hocon/config_value.hpp>
+namespace hocon {
+
+    /**
+     * An AbstractConfigValue which contains other values. Java has no way to
+     * express "this has to be an AbstractConfigValue also" other than making
+     * AbstractConfigValue an interface which would be aggravating. But we can say
+     * we are a ConfigValue.
+     */
+    class container {
+    public:
+        /**
+         * Replace a child of this value. CAUTION if replacement is null, delete the
+         * child, which may also delete the parent, or make the parent into a
+         * non-container.
+         */
+        virtual shared_value replace_child(shared_value child, shared_value replacement) const = 0;
+
+        /**
+         * Super-expensive full traversal to see if descendant is anywhere
+         * underneath this container.
+         */
+        virtual bool has_descendant(shared_value descendant) const = 0;
+    };
+} //namespace hocon
+

--- a/lib/inc/internal/exception.hpp
+++ b/lib/inc/internal/exception.hpp
@@ -3,8 +3,15 @@
 namespace hocon {
 
     class config_exception : public std::runtime_error {
+
     public:
         config_exception(std::string const& message) : runtime_error(message) { }
     };
 
+    class unsupported_operation_exception : public std::runtime_error {
+
+    public:
+        unsupported_operation_exception(std::string const& message) : runtime_error(message) { };
+
+    };
 }  // namespace hocon

--- a/lib/inc/internal/exception.hpp
+++ b/lib/inc/internal/exception.hpp
@@ -3,16 +3,14 @@
 namespace hocon {
 
     class config_exception : public std::runtime_error {
-
     public:
         config_exception(std::string const& message) : runtime_error(message) { }
         config_exception(std::string const& message, std::exception const& e) : runtime_error(message + " " + e.what()) { }
     };
 
     class unsupported_operation_exception : public std::runtime_error {
-
     public:
-        unsupported_operation_exception(std::string const& message) : runtime_error(message) { };
-
+        unsupported_operation_exception(std::string const& message) : runtime_error(message) { }
     };
+
 }  // namespace hocon

--- a/lib/inc/internal/exception.hpp
+++ b/lib/inc/internal/exception.hpp
@@ -6,6 +6,7 @@ namespace hocon {
 
     public:
         config_exception(std::string const& message) : runtime_error(message) { }
+        config_exception(std::string const& message, std::exception const& e) : runtime_error(message + " " + e.what()) { }
     };
 
     class unsupported_operation_exception : public std::runtime_error {

--- a/lib/inc/internal/resolve_context.hpp
+++ b/lib/inc/internal/resolve_context.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 namespace hocon {
-    //TODO: Implement this class >_>
+    // TODO: Implement this class >_>
     class resolve_context {
-
     };
-} //namespace hocon
+}  // namespace hocon

--- a/lib/inc/internal/resolve_context.hpp
+++ b/lib/inc/internal/resolve_context.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace hocon {
+    //TODO: Implement this class >_>
+    class resolve_context {
+
+    };
+} //namespace hocon

--- a/lib/inc/internal/resolve_result.hpp
+++ b/lib/inc/internal/resolve_result.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <hocon/config_value.hpp>
+
+namespace hocon {
+    //TODO: yolo
+    template<typename T>
+    class resolve_result : public config_value {
+    };
+} //namespace hocon

--- a/lib/inc/internal/resolve_result.hpp
+++ b/lib/inc/internal/resolve_result.hpp
@@ -2,8 +2,8 @@
 #include <hocon/config_value.hpp>
 
 namespace hocon {
-    //TODO: yolo
+    // TODO: yolo
     template<typename T>
     class resolve_result : public config_value {
     };
-} //namespace hocon
+}  // namespace hocon

--- a/lib/inc/internal/resolve_source.hpp
+++ b/lib/inc/internal/resolve_source.hpp
@@ -3,8 +3,5 @@
 namespace hocon {
 
     class resolve_source {
-
     };
-
 }  // namespace hocon
-

--- a/lib/inc/internal/resolve_source.hpp
+++ b/lib/inc/internal/resolve_source.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace hocon {
+
+    class resolve_source {
+
+    };
+
+}  // namespace hocon
+

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -15,19 +15,16 @@
 namespace hocon {
 
     class simple_config_list : public config_list, public container, public std::enable_shared_from_this<simple_config_list> {
-
     public:
-
         // This would be useful if we need to iterator over all the values in a list
         // We don't know if we need it yet
         // using iterator = std::vector<shared_value>::const_iterator;
-
         simple_config_list(shared_origin origin, std::vector<shared_value> value);
         simple_config_list(shared_origin origin, std::vector<shared_value> value, resolve_status status);
         config_value_type value_type() const;
-        //unwrapped()
+        // unwrapped()
         resolve_status get_resolve_status() const {return _resolved ? resolve_status::RESOLVED : resolve_status::UNRESOLVED;}
-        shared_value replace_child(shared_value child, shared_value replacement) const override; 
+        shared_value replace_child(shared_value child, shared_value replacement) const override;
         bool has_descendant(shared_value descendant) const;
 
         resolve_result<simple_config_list> resolve_substitutions(std::shared_ptr<resolve_context> context,
@@ -39,8 +36,8 @@ namespace hocon {
         shared_value get(int index) const {return _value[index];}
 
         // YOLO
-        int index_of(shared_value v) { 
-            auto pos = find(_value.begin(), _value.end(), v); 
+        int index_of(shared_value v) {
+            auto pos = find(_value.begin(), _value.end(), v);
             if (pos == _value.end()) {
                 return -1;
             } else {
@@ -82,9 +79,8 @@ namespace hocon {
 
         std::shared_ptr<simple_config_list> modify(no_exceptions_modifier modifier, resolve_status new_resolve_status);
         std::shared_ptr<simple_config_list> modify_may_throw(std::shared_ptr<modifier> modifier, resolve_status new_resolve_status);
-        
-        class resolve_modifier : public modifier {
 
+        class resolve_modifier : public modifier {
         public:
             resolve_modifier(std::shared_ptr<resolve_context> context, std::shared_ptr<resolve_source> source);
             shared_value modify_child_may_throw(std::string key, shared_value v) const override;
@@ -93,8 +89,7 @@ namespace hocon {
             std::vector<shared_value> _value;
             const std::shared_ptr<resolve_source> _source;
             std::shared_ptr<resolve_context> _context;
-       
         };
     };
 
-} //namespace hocon
+}   // namespace hocon

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <hocon/config_value.hpp>
+#include <hocon/config_list.hpp>
+#include <hocon/config_render_options.hpp>
+#include <internal/container.hpp>
+#include <internal/resolve_result.hpp>
+#include <internal/resolve_context.hpp>
+#include <internal/resolve_source.hpp>
+#include <internal/exception.hpp>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+namespace hocon {
+
+    class simple_config_list : public config_list, public container, public std::enable_shared_from_this<simple_config_list> {
+
+    public:
+
+        // This would be useful if we need to iterator over all the values in a list
+        // We don't know if we need it yet
+        // using iterator = std::vector<shared_value>::const_iterator;
+
+        simple_config_list(shared_origin origin, std::vector<shared_value> value);
+        simple_config_list(shared_origin origin, std::vector<shared_value> value, resolve_status status);
+        config_value_type value_type() const;
+        //unwrapped()
+        resolve_status get_resolve_status() const {return _resolved ? resolve_status::RESOLVED : resolve_status::UNRESOLVED;}
+        shared_value replace_child(shared_value child, shared_value replacement) const override; 
+        bool has_descendant(shared_value descendant) const;
+
+        resolve_result<simple_config_list> resolve_substitutions(std::shared_ptr<resolve_context> context,
+                                                                 std::shared_ptr<resolve_source> source) const;
+        std::shared_ptr<simple_config_list> relativized(const std::string prefix) const;
+
+        bool contains(shared_value v) const { return std::find(_value.begin(), _value.end(), v) != _value.end(); }
+        bool contains_all(std::vector<shared_value>) const;
+        shared_value get(int index) const {return _value[index];}
+
+        // YOLO
+        int index_of(shared_value v) { 
+            auto pos = find(_value.begin(), _value.end(), v); 
+            if (pos == _value.end()) {
+                return -1;
+            } else {
+                return pos - _value.begin();
+            }
+        }
+
+
+        bool is_empty() const {return _value.empty();}
+        int size() const { return _value.size(); }
+        std::vector<shared_value> sub_list(int from_index, int to_index) const;
+
+        bool add(shared_value e) const {throw unsupported_operation_exception(exception_string() + "add");}
+        void add(int index, shared_value element) const {throw unsupported_operation_exception(exception_string() + "add");}
+        bool add_all(std::vector<shared_value>) const {throw unsupported_operation_exception(exception_string() + "add_all");}
+        bool add_all(int index, std::vector<shared_value>) const {throw unsupported_operation_exception(exception_string() + "add_all");}
+        void clear() const {throw unsupported_operation_exception(exception_string() + "clear");}
+        bool remove(shared_value v) const {throw unsupported_operation_exception(exception_string() + "remove");}
+        shared_value remove(int index) const {throw unsupported_operation_exception(exception_string() + "remove");}
+        bool remove_all(std::vector<shared_value>) const {throw unsupported_operation_exception(exception_string() + "remove_all");}
+        bool retain_all(std::vector<shared_value>) const {throw unsupported_operation_exception(exception_string() + "retain_all");}
+        shared_value set(int index, shared_value element) const {throw unsupported_operation_exception(exception_string() + "set");}
+
+        const std::shared_ptr<simple_config_list> concatenate(simple_config_list other);
+        std::shared_ptr<const config_list> with_origin(shared_origin origin);
+
+        bool operator==(simple_config_list const& other) const;
+
+    protected:
+        void render_list(std::string s, int indent, bool atRoot, std::shared_ptr<config_render_options> options);
+        std::shared_ptr<simple_config_list> new_copy(shared_origin) {return std::enable_shared_from_this<simple_config_list>::shared_from_this();}
+
+    private:
+        static const long _serial_version_UID = 2L;
+        const std::vector<shared_value> _value;
+        const bool _resolved;
+
+        static const std::string exception_string() {return "config_list is immutable, you can't call simple_config_list.";}
+
+        std::shared_ptr<simple_config_list> modify(no_exceptions_modifier modifier, resolve_status new_resolve_status);
+        std::shared_ptr<simple_config_list> modify_may_throw(std::shared_ptr<modifier> modifier, resolve_status new_resolve_status);
+        
+        class resolve_modifier : public modifier {
+
+        public:
+            resolve_modifier(std::shared_ptr<resolve_context> context, std::shared_ptr<resolve_source> source);
+            shared_value modify_child_may_throw(std::string key, shared_value v) const override;
+
+        private:
+            std::vector<shared_value> _value;
+            const std::shared_ptr<resolve_source> _source;
+            std::shared_ptr<resolve_context> _context;
+       
+        };
+    };
+
+} //namespace hocon

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -21,9 +21,9 @@ namespace hocon {
         // using iterator = std::vector<shared_value>::const_iterator;
         simple_config_list(shared_origin origin, std::vector<shared_value> value);
         simple_config_list(shared_origin origin, std::vector<shared_value> value, resolve_status status);
-        config_value_type value_type() const;
+        config_value_type value_type() const { return config_value_type::LIST; }
         // unwrapped()
-        resolve_status get_resolve_status() const {return _resolved ? resolve_status::RESOLVED : resolve_status::UNRESOLVED;}
+        resolve_status get_resolve_status() const {return _resolved;}
         shared_value replace_child(shared_value child, shared_value replacement) const override;
         bool has_descendant(shared_value descendant) const;
 
@@ -73,7 +73,7 @@ namespace hocon {
     private:
         static const long _serial_version_UID = 2L;
         const std::vector<shared_value> _value;
-        const bool _resolved;
+        const resolve_status _resolved;
 
         static const std::string exception_string() {return "config_list is immutable, you can't call simple_config_list.";}
 

--- a/lib/inc/internal/tokenizer.hpp
+++ b/lib/inc/internal/tokenizer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "tokens.hpp"
-#include "config_exception.hpp"
+#include <internal/exception.hpp>
 #include <hocon/config_syntax.hpp>
 
 #include <boost/nowide/fstream.hpp>

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -1,6 +1,6 @@
 #include <hocon/config.hpp>
 #include <internal/values/config_null.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/default_transformer.hpp>
 #include <internal/values/config_boolean.hpp>
 #include <internal/values/config_number.hpp>

--- a/lib/src/default_transformer.cc
+++ b/lib/src/default_transformer.cc
@@ -7,7 +7,7 @@
 #include <internal/values/config_boolean.hpp>
 #include <internal/values/config_string.hpp>
 #include <hocon/config_object.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 
 using namespace std;
 

--- a/lib/src/nodes/config_node_field.cc
+++ b/lib/src/nodes/config_node_field.cc
@@ -1,5 +1,5 @@
 #include <internal/nodes/config_node_field.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/nodes/config_node_single_token.hpp>
 #include <internal/tokens.hpp>
 #include <internal/nodes/config_node_comment.hpp>

--- a/lib/src/nodes/config_node_path.cc
+++ b/lib/src/nodes/config_node_path.cc
@@ -1,5 +1,5 @@
 #include <internal/nodes/config_node_path.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 
 using namespace std;
 

--- a/lib/src/nodes/config_node_root.cc
+++ b/lib/src/nodes/config_node_root.cc
@@ -1,5 +1,5 @@
 #include <internal/nodes/config_node_root.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/nodes/config_node_array.hpp>
 #include <internal/nodes/config_node_object.hpp>
 #include <internal/path_parser.hpp>

--- a/lib/src/nodes/config_node_simple_value.cc
+++ b/lib/src/nodes/config_node_simple_value.cc
@@ -1,5 +1,5 @@
 #include <internal/nodes/config_node_simple_value.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/tokens.hpp>
 #include <internal/values/config_string.hpp>
 

--- a/lib/src/objects/config_object.cc
+++ b/lib/src/objects/config_object.cc
@@ -1,6 +1,6 @@
 #include <hocon/config_object.hpp>
 #include <hocon/config.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <hocon/path.hpp>
 
 using namespace std;

--- a/lib/src/objects/simple_config_object.cc
+++ b/lib/src/objects/simple_config_object.cc
@@ -1,6 +1,6 @@
 #include <internal/objects/simple_config_object.hpp>
 #include <hocon/config_value.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/simple_config_origin.hpp>
 
 using namespace std;

--- a/lib/src/parseable.cc
+++ b/lib/src/parseable.cc
@@ -4,7 +4,7 @@
 #include <internal/nodes/abstract_config_node.hpp>
 #include <internal/nodes/config_node_object.hpp>
 #include <internal/simple_config_document.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/tokenizer.hpp>
 #include <internal/config_document_parser.hpp>
 #include <internal/simple_include_context.hpp>

--- a/lib/src/path.cc
+++ b/lib/src/path.cc
@@ -1,5 +1,5 @@
 #include <hocon/path.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/path_builder.hpp>
 #include <internal/config_util.hpp>
 #include <internal/path_parser.hpp>

--- a/lib/src/simple_config_document.cc
+++ b/lib/src/simple_config_document.cc
@@ -1,6 +1,6 @@
 #include <hocon/config_parse_options.hpp>
 #include <internal/simple_config_document.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/tokenizer.hpp>
 #include <internal/config_document_parser.hpp>
 #include <sstream>

--- a/lib/src/simple_config_list.cc
+++ b/lib/src/simple_config_list.cc
@@ -3,4 +3,5 @@
 using namespace std;
 
 namespace hocon {
-} //namespace hocon
+
+}  // namespace hocon

--- a/lib/src/simple_config_list.cc
+++ b/lib/src/simple_config_list.cc
@@ -1,0 +1,6 @@
+#include <internal/simple_config_list.hpp>
+
+using namespace std;
+
+namespace hocon {
+} //namespace hocon

--- a/lib/src/simple_config_list.cc
+++ b/lib/src/simple_config_list.cc
@@ -1,7 +1,19 @@
+#include <hocon/config_value.hpp>
 #include <internal/simple_config_list.hpp>
 
 using namespace std;
 
 namespace hocon {
 
+    simple_config_list::simple_config_list(shared_origin origin, std::vector<shared_value> value)
+            : config_list(move(origin)), _value(move(value)), _resolved(resolve_status_from_values(_value)) { }
+
+
+    simple_config_list::simple_config_list(shared_origin origin, std::vector<shared_value> value,
+                                           resolve_status status) : simple_config_list(move(origin), move(value)){
+
+        if (status != _resolved) {
+            throw config_exception("simple_config_list created with wrong resolve status");
+        }
+    }
 }  // namespace hocon

--- a/lib/src/tokens.cc
+++ b/lib/src/tokens.cc
@@ -1,5 +1,5 @@
 #include <internal/tokens.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <internal/tokenizer.hpp>
 #include <iostream>
 

--- a/lib/src/values/config_number.cc
+++ b/lib/src/values/config_number.cc
@@ -2,7 +2,7 @@
 #include <internal/values/config_int.hpp>
 #include <internal/values/config_long.hpp>
 #include <internal/values/config_double.hpp>
-#include <internal/config_exception.hpp>
+#include <internal/exception.hpp>
 #include <limits>
 
 using namespace std;

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -35,6 +35,15 @@ namespace hocon {
         return result;
     }
 
+    resolve_status resolve_status_from_values(std::vector<shared_value> const& values) {
+        for (auto& v: values) {
+            if (v->get_resolve_status() == resolve_status::UNRESOLVED) {
+                return resolve_status::UNRESOLVED;
+            }
+        }
+        return resolve_status::RESOLVED;
+    }
+
     void config_value::render(std::string &result, int indent, bool at_root, std::string at_key,
                                          config_render_options options) const {
         if (!at_key.empty()) {

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -1,4 +1,5 @@
 #include <hocon/config_value.hpp>
+#include <internal/exception.hpp>
 #include <internal/config_util.hpp>
 #include <hocon/config_object.hpp>
 #include <internal/objects/simple_config_object.hpp>


### PR DESCRIPTION
In order to port SimpleConfig List, add all the header files that
are needed. This includes the header file for SimpleConfigList and
several other classes that it relies on. At the moment, the header
files for resolve_context, resolve_result, and resolve_source are
just stubs without any methods or instance variables.