### PR TITLE
(HC-39) Port header files for SimpleConfigList

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,7 @@ set(PROJECT_SOURCES
     src/config.cc
     src/default_transformer.cc
     src/substitution_expression.cc
+    src/simple_config_list.cc
 )
 
 ## An object target is generated that can be used by both the library and test executable targets.

--- a/lib/inc/hocon/config_list.hpp
+++ b/lib/inc/hocon/config_list.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "config_value.hpp"
+#include "config_origin.hpp"
+#include <vector>
+#include "export.h"
+
+namespace hocon {
+
+    /**
+     * Subtype of {@link ConfigValue} representing a list value, as in JSON's
+     * {@code [1,2,3]} syntax.
+     *
+     * <p>
+     * {@code ConfigList} implements {@code java.util.List<ConfigValue>} so you can
+     * use it like a regular Java list. Or call {@link #unwrapped()} to unwrap the
+     * list elements into plain Java values.
+     *
+     * <p>
+     * Like all {@link ConfigValue} subtypes, {@code ConfigList} is immutable. This
+     * makes it threadsafe and you never have to create "defensive copies." The
+     * mutator methods from {@link java.util.List} all throw
+     * {@link java.lang.UnsupportedOperationException}.
+     *
+     * <p>
+     * The {@link ConfigValue#valueType} method on a list returns
+     * {@link ConfigValueType#LIST}.
+     *
+     * <p>
+     * <em>Do not implement {@code ConfigList}</em>; it should only be implemented
+     * by the config library. Arbitrary implementations will not work because the
+     * library internals assume a specific concrete implementation. Also, this
+     * interface is likely to grow new methods over time, so third-party
+     * implementations will break.
+     *
+     */
+
+    class LIBCPP_HOCON_EXPORT config_list : public config_value {
+    public:
+        config_list(shared_origin origin) : config_value(move(origin)) {}
+
+        virtual std::shared_ptr<const config_list> with_origin(shared_origin origin) const = 0;
+    };
+}  // namespace hocon

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -116,11 +116,28 @@ namespace hocon {
          */
         shared_config at_path(std::string const& path_expression) const;
 
+        /**
+         * This is used when including one file in another; the included file is
+         * relativized to the path it's included into in the parent file. The point
+         * is that if you include a file at foo.bar in the parent, and the included
+         * file as a substitution ${a.b.c}, the included substitution now needs to
+         * be ${foo.bar.a.b.c} because we resolve substitutions globally only after
+         * parsing everything.
+         *
+         * @param prefix
+         * @return value relativized to the given path or the same value if nothing
+         *         to do
+         */
+        shared_value relativized(std::string prefix) const { return shared_from_this(); }
+
+        virtual resolve_status get_resolve_status() const;
+
+        friend resolve_status resolve_status_from_values(std::vector<shared_value> const& v);
+
     protected:
         config_value(shared_origin origin);
 
         virtual std::string transform_to_string() const;
-        virtual resolve_status get_resolve_status() const;
         void render(std::string& result, int indent, bool at_root, std::string at_key,
                     config_render_options options) const;
         virtual void render(std::string& result, int indent, bool at_root, config_render_options options) const;
@@ -128,8 +145,22 @@ namespace hocon {
         shared_config at_key(shared_origin origin, std::string const& key) const;
         shared_config at_path(shared_origin origin, path raw_path) const;
 
+        class modifier {
+         public:
+            virtual shared_value modify_child_may_throw(std::string key_or_null, shared_value v) const = 0;
+        };
+
+        class no_exceptions_modifier : public modifier {
+        public:
+            no_exceptions_modifier(std::string prefix);
+
+            shared_value modify_child_may_throw(std::string key_or_null, shared_value v) const override;
+            shared_value modify_child(std::string key, shared_value v) const;
+        private:
+            std::string _prefix;
+        };
+
     private:
         shared_origin _origin;
     };
-
 }  // namespace hocon

--- a/lib/inc/internal/config_exception.hpp
+++ b/lib/inc/internal/config_exception.hpp
@@ -5,6 +5,7 @@ namespace hocon {
     class config_exception : public std::runtime_error {
     public:
         config_exception(std::string const& message) : runtime_error(message) { }
+        config_exception(std::string const& message, std::exception const& e) : runtime_error(message + " " + e.what()) { }
     };
 
 }  // namespace hocon

--- a/lib/inc/internal/container.hpp
+++ b/lib/inc/internal/container.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <hocon/config_value.hpp>
+namespace hocon {
+
+    /**
+     * An AbstractConfigValue which contains other values. Java has no way to
+     * express "this has to be an AbstractConfigValue also" other than making
+     * AbstractConfigValue an interface which would be aggravating. But we can say
+     * we are a ConfigValue.
+     */
+    class container {
+    public:
+        /**
+         * Replace a child of this value. CAUTION if replacement is null, delete the
+         * child, which may also delete the parent, or make the parent into a
+         * non-container.
+         */
+        virtual shared_value replace_child(shared_value child, shared_value replacement) const = 0;
+
+        /**
+         * Super-expensive full traversal to see if descendant is anywhere
+         * underneath this container.
+         */
+        virtual bool has_descendant(shared_value descendant) const = 0;
+    };
+
+}  // namespace hocon

--- a/lib/inc/internal/resolve_context.hpp
+++ b/lib/inc/internal/resolve_context.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace hocon {
+    // TODO: Implement this class >_>
+    class resolve_context {
+    };
+}  // namespace hocon

--- a/lib/inc/internal/resolve_result.hpp
+++ b/lib/inc/internal/resolve_result.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <internal/resolve_context.hpp>
+#include <memory>
+
+namespace hocon {
+    // TODO: yolo
+    template<typename V>
+    class resolve_result {
+    public:
+        resolve_result(resolve_context context, V value) :
+            _context(std::move(context)), _value(std::move(value)) {}
+
+    private:
+        resolve_context _context;
+        V _value;
+    };
+}  // namespace hocon

--- a/lib/inc/internal/resolve_source.hpp
+++ b/lib/inc/internal/resolve_source.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace hocon {
+
+    class resolve_source {
+    };
+}  // namespace hocon

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <hocon/config_value.hpp>
+#include <hocon/config_list.hpp>
+#include <hocon/config_render_options.hpp>
+#include <internal/container.hpp>
+#include <internal/resolve_result.hpp>
+#include <internal/resolve_context.hpp>
+#include <internal/resolve_source.hpp>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+namespace hocon {
+
+    class simple_config_list : public config_list, public container, public std::enable_shared_from_this<simple_config_list> {
+    public:
+        // This would be useful if we need to iterator over all the values in a list
+        // We don't know if we need it yet
+        // using iterator = std::vector<shared_value>::const_iterator;
+
+        simple_config_list(shared_origin origin, std::vector<shared_value> value);
+        simple_config_list(shared_origin origin, std::vector<shared_value> value, resolve_status status);
+
+        config_value_type value_type() const override { return config_value_type::LIST; }
+        // unwrapped()
+        resolve_status get_resolve_status() const override { return _resolved; }
+
+        shared_value replace_child(shared_value child, shared_value replacement) const override;
+        bool has_descendant(shared_value descendant) const override;
+
+        resolve_result<std::shared_ptr<const simple_config_list>>
+            resolve_substitutions(std::shared_ptr<resolve_context> context, std::shared_ptr<resolve_source> source) const;
+        std::shared_ptr<const simple_config_list> relativized(const std::string prefix) const;
+
+        bool contains(shared_value v) const { return std::find(_value.begin(), _value.end(), v) != _value.end(); }
+        bool contains_all(std::vector<shared_value>) const;
+        shared_value get(int index) const { return _value[index]; }
+
+        // YOLO
+        int index_of(shared_value v) {
+            auto pos = find(_value.begin(), _value.end(), v);
+            if (pos == _value.end()) {
+                return -1;
+            } else {
+                return pos - _value.begin();
+            }
+        }
+
+
+        bool is_empty() const {return _value.empty();}
+        int size() const { return _value.size(); }
+        std::vector<shared_value> sub_list(int from_index, int to_index) const;
+
+        std::shared_ptr<const simple_config_list> concatenate(simple_config_list other) const;
+        std::shared_ptr<const config_list> with_origin(shared_origin origin) const override;
+
+        bool operator==(simple_config_list const& other) const;
+
+    protected:
+        void render_list(std::string s, int indent, bool atRoot, std::shared_ptr<config_render_options> options) const;
+        std::shared_ptr<const simple_config_list> new_copy(shared_origin) const {return std::enable_shared_from_this<simple_config_list>::shared_from_this();}
+
+    private:
+        static const long _serial_version_UID = 2L;
+        const std::vector<shared_value> _value;
+        const resolve_status _resolved;
+
+        std::shared_ptr<const simple_config_list> modify(no_exceptions_modifier modifier, resolve_status new_resolve_status) const;
+        std::shared_ptr<const simple_config_list> modify_may_throw(std::shared_ptr<modifier> modifier, resolve_status new_resolve_status) const;
+
+        class resolve_modifier : public modifier {
+        public:
+            resolve_modifier(std::shared_ptr<resolve_context> context, std::shared_ptr<resolve_source> source);
+            shared_value modify_child_may_throw(std::string key, shared_value v) const override;
+
+        private:
+            std::vector<shared_value> _value;
+            const std::shared_ptr<resolve_source> _source;
+            std::shared_ptr<resolve_context> _context;
+        };
+    };
+
+}   // namespace hocon

--- a/lib/src/simple_config_list.cc
+++ b/lib/src/simple_config_list.cc
@@ -1,0 +1,95 @@
+#include <hocon/config_value.hpp>
+#include <internal/simple_config_list.hpp>
+#include <internal/config_exception.hpp>
+
+using namespace std;
+
+namespace hocon {
+
+    simple_config_list::simple_config_list(shared_origin origin, std::vector<shared_value> value)
+            : config_list(move(origin)), _value(move(value)), _resolved(resolve_status_from_values(_value)) { }
+
+
+    simple_config_list::simple_config_list(shared_origin origin, std::vector<shared_value> value,
+                                           resolve_status status) : simple_config_list(move(origin), move(value)){
+        if (status != _resolved) {
+            throw config_exception("simple_config_list created with wrong resolve status");
+        }
+    }
+
+    shared_value simple_config_list::replace_child(shared_value child, shared_value replacement) const
+    {
+        return {};
+    }
+
+    bool simple_config_list::has_descendant(shared_value descendant) const
+    {
+        return true;
+    }
+
+    resolve_result<shared_ptr<const simple_config_list>>
+    simple_config_list::resolve_substitutions(std::shared_ptr<resolve_context> context,
+                                              std::shared_ptr<resolve_source> source) const
+    {
+        return {resolve_context(), std::enable_shared_from_this<simple_config_list>::shared_from_this()};
+    }
+
+    std::shared_ptr<const simple_config_list> simple_config_list::relativized(const std::string prefix) const
+    {
+        return {};
+    }
+
+    std::vector<shared_value> simple_config_list::sub_list(int from_index, int to_index) const
+    {
+        return {};
+    }
+
+    std::shared_ptr<const simple_config_list> simple_config_list::concatenate(simple_config_list other) const
+    {
+        return {};
+    }
+
+    std::shared_ptr<const config_list> simple_config_list::with_origin(shared_origin origin) const
+    {
+        return {};
+    }
+
+    bool simple_config_list::operator==(simple_config_list const& other) const
+    {
+        return true;
+    }
+
+    void simple_config_list::render_list(std::string s,
+                                         int indent,
+                                         bool atRoot,
+                                         std::shared_ptr<config_render_options> options) const
+    {
+    }
+
+    std::shared_ptr<const simple_config_list>
+    simple_config_list::modify(no_exceptions_modifier modifier,
+                               resolve_status new_resolve_status) const
+    {
+        return {};
+    }
+
+    std::shared_ptr<const simple_config_list>
+    simple_config_list::modify_may_throw(std::shared_ptr<modifier> modifier,
+                                         resolve_status new_resolve_status) const
+    {
+        return {};
+    }
+
+    simple_config_list::resolve_modifier::resolve_modifier(std::shared_ptr<resolve_context> context,
+                                                           std::shared_ptr<resolve_source> source)
+    {
+    }
+
+    shared_value
+    simple_config_list::resolve_modifier::modify_child_may_throw(std::string key,
+                                                                 shared_value v) const
+    {
+        return v;
+    }
+
+}  // namespace hocon

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -1,6 +1,7 @@
 #include <hocon/config_value.hpp>
 #include <internal/config_util.hpp>
 #include <hocon/config_object.hpp>
+#include <internal/config_exception.hpp>
 #include <internal/objects/simple_config_object.hpp>
 #include <internal/simple_config_origin.hpp>
 
@@ -31,6 +32,15 @@ namespace hocon {
         string result;
         render(result, 0, true, "", options);
         return result;
+    }
+
+    resolve_status resolve_status_from_values(std::vector<shared_value> const& values) {
+        for (auto& v : values) {
+            if (v->get_resolve_status() == resolve_status::UNRESOLVED) {
+                return resolve_status::UNRESOLVED;
+            }
+        }
+        return resolve_status::RESOLVED;
     }
 
     void config_value::render(std::string &result, int indent, bool at_root, std::string at_key,
@@ -88,6 +98,22 @@ namespace hocon {
     shared_config config_value::at_path(std::string const& path_expression) const {
         shared_origin origin = make_shared<simple_config_origin>("at_path(" + path_expression + ")");
         return at_path(move(origin), path::new_path(path_expression));
+    }
+
+    config_value::no_exceptions_modifier::no_exceptions_modifier(string prefix): _prefix(std::move(prefix)) {}
+
+    shared_value config_value::no_exceptions_modifier::modify_child_may_throw(string key_or_null, shared_value v) const {
+        try {
+            return modify_child(key_or_null, v);
+        } catch (runtime_error& e) {
+            throw e;
+        } catch (exception& e) {
+            throw config_exception("Unexpected exception:", e);
+        }
+    }
+
+    shared_value config_value::no_exceptions_modifier::modify_child(string key, shared_value v) const {
+        return v->relativized(_prefix);
     }
 
 }  // namespace hocon


### PR DESCRIPTION
In order to port SimpleConfig List, add all the header files that
are needed. This includes the header file for SimpleConfigList and
several other classes that it relies on. At the moment, the header
files for resolve_context, resolve_result, and resolve_source are
just stubs without any methods or instance variables.

Also implements stubs for methods so everything links.