### PR TITLE
(HC-39) Implement part of resolve_substitutions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,6 +64,8 @@ set(PROJECT_SOURCES
     src/simple_config_list.cc
     src/config_delayed_merge.cc
     src/config_delayed_merge_object.cc
+    src/resolve_context.cc
+    src/resolve_source.cc
 )
 
 

--- a/lib/inc/hocon/config_list.hpp
+++ b/lib/inc/hocon/config_list.hpp
@@ -38,7 +38,5 @@ namespace hocon {
     class LIBCPP_HOCON_EXPORT config_list : public config_value {
     public:
         config_list(shared_origin origin) : config_value(move(origin)) {}
-
-        virtual std::shared_ptr<const config_list> with_origin(shared_origin origin) const = 0;
     };
 }  // namespace hocon

--- a/lib/inc/hocon/config_origin.hpp
+++ b/lib/inc/hocon/config_origin.hpp
@@ -2,6 +2,8 @@
 
 #include "types.hpp"
 #include <memory>
+#include <string>
+#include <vector>
 #include "export.h"
 
 namespace hocon {
@@ -34,7 +36,7 @@ namespace hocon {
          *
          * @return string describing the origin
          */
-        LIBCPP_HOCON_EXPORT virtual std::string description() const = 0;
+        LIBCPP_HOCON_EXPORT virtual std::string const& description() const = 0;
 
         /**
          * Returns a {@code ConfigOrigin} based on this one, but with the given
@@ -62,6 +64,18 @@ namespace hocon {
          * @return line number or -1 if none is available
          */
         LIBCPP_HOCON_EXPORT virtual int line_number() const = 0;
+
+        /**
+         * Returns any comments that appeared to "go with" this place in the file.
+         * Often an empty list, but never null. The details of this are subject to
+         * change, but at the moment comments that are immediately before an array
+         * element or object field, with no blank line after the comment, "go with"
+         * that element or field.
+         *
+         * @return any comments that seemed to "go with" this origin, empty list if
+         *         none
+         */
+        LIBCPP_HOCON_EXPORT virtual std::vector<std::string> const& comments() const = 0;
     };
 
 }  // namespace hocon

--- a/lib/inc/hocon/config_render_options.hpp
+++ b/lib/inc/hocon/config_render_options.hpp
@@ -51,7 +51,7 @@ namespace hocon {
          *
          * @return true if comments should be rendered
          */
-        bool get_comments();
+        bool get_comments() const;
 
         /**
          * Returns options with origin comments toggled. If this is enabled, the
@@ -77,7 +77,7 @@ namespace hocon {
          *
          * @return true if origin comments should be rendered
          */
-        bool get_origin_comments();
+        bool get_origin_comments() const;
 
         /**
          * Returns options with formatting toggled. Formatting means indentation and
@@ -95,7 +95,7 @@ namespace hocon {
          *
          * @return true if the options enable formatting
          */
-        bool get_formatted();
+        bool get_formatted() const;
 
         /**
          * Returns options with JSON toggled. JSON means that HOCON extensions
@@ -116,7 +116,7 @@ namespace hocon {
          *
          * @return true if only JSON should be rendered
          */
-        bool get_json();
+        bool get_json() const;
 
     private:
         bool _origin_comments;

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -48,6 +48,7 @@ namespace hocon {
         friend class config;
         friend class config_object;
         friend class simple_config_object;
+        friend class simple_config_list;
     public:
         /**
          * The origin of the value (file, line number, etc.), for debugging and
@@ -162,6 +163,7 @@ namespace hocon {
         void render(std::string& result, int indent, bool at_root, std::string at_key,
                     config_render_options options) const;
         virtual void render(std::string& result, int indent, bool at_root, config_render_options options) const;
+        static void indent(std::string& result, int indent, config_render_options const& options);
 
         shared_config at_key(shared_origin origin, std::string const& key) const;
         shared_config at_path(shared_origin origin, path raw_path) const;

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -115,15 +115,25 @@ namespace hocon {
         shared_config at_key(std::string const& key) const;
 
         /**
-         * Places the value inside a {@link Config} at the given path. See also
-         * {@link ConfigValue#atKey(String)}.
+         * Places the value inside a {@link config} at the given path. See also
+         * {@link config_value#at_key(String)}.
          *
          * @param path
          *            path to store this value at.
-         * @return a {@code Config} instance containing this value at the given
+         * @return a {@code config} instance containing this value at the given
          *         path.
          */
         shared_config at_path(std::string const& path_expression) const;
+
+        /**
+         * Returns a {@code config_value} based on this one, but with the given
+         * origin. This is useful when you are parsing a new format of file or setting
+         * comments for a single config_value.
+         *
+         * @param origin the origin set on the returned value
+         * @return the new config_value with the given origin
+         */
+        virtual shared_value with_origin(shared_origin origin) const;
 
         /**
          * This is used when including one file in another; the included file is
@@ -155,6 +165,8 @@ namespace hocon {
 
         shared_config at_key(shared_origin origin, std::string const& key) const;
         shared_config at_path(shared_origin origin, path raw_path) const;
+
+        virtual shared_value new_copy(shared_origin origin) const = 0;
 
         virtual resolve_result<shared_value>
             resolve_substitutions(resolve_context const& context, resolve_source const& source) const;

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -10,6 +10,11 @@
 namespace hocon {
 
     class unmergeable;
+    class resolve_source;
+    class resolve_context;
+
+    template<typename T>
+    struct resolve_result;
 
     /**
      * The type of a configuration value (following the <a
@@ -151,20 +156,23 @@ namespace hocon {
         shared_config at_key(shared_origin origin, std::string const& key) const;
         shared_config at_path(shared_origin origin, path raw_path) const;
 
+        virtual resolve_result<shared_value>
+            resolve_substitutions(resolve_context const& context, resolve_source const& source) const;
+
         static std::vector<shared_value> replace_child_in_list(std::vector<shared_value> const& values,
                                                                shared_value const& child, shared_value replacement);
         static bool has_descendant_in_list(std::vector<shared_value> const& values, shared_value const& descendant);
 
         class modifier {
          public:
-            virtual shared_value modify_child_may_throw(std::string key_or_null, shared_value v) const = 0;
+            virtual shared_value modify_child_may_throw(std::string key_or_null, shared_value v) = 0;
         };
 
         class no_exceptions_modifier : public modifier {
         public:
             no_exceptions_modifier(std::string prefix);
 
-            shared_value modify_child_may_throw(std::string key_or_null, shared_value v) const override;
+            shared_value modify_child_may_throw(std::string key_or_null, shared_value v) override;
             shared_value modify_child(std::string key, shared_value v) const;
         private:
             std::string _prefix;

--- a/lib/inc/internal/config_delayed_merge.hpp
+++ b/lib/inc/internal/config_delayed_merge.hpp
@@ -13,6 +13,9 @@ namespace hocon {
         config_value_type value_type() const override;
         std::vector<shared_value> const& unmerged_values() const override;
 
+    protected:
+        shared_value new_copy(shared_origin) const override;
+
     private:
         std::vector<shared_value> _stack;
     };

--- a/lib/inc/internal/config_delayed_merge_object.hpp
+++ b/lib/inc/internal/config_delayed_merge_object.hpp
@@ -18,6 +18,7 @@ namespace hocon {
         shared_object without_path(path raw_path) const override;
         shared_object with_only_path(path raw_path) const override;
         shared_object with_only_path_or_null(path raw_path) const override;
+        shared_value new_copy(shared_origin origin) const override;
 
     private:
         const std::vector<shared_value> _stack;

--- a/lib/inc/internal/config_exception.hpp
+++ b/lib/inc/internal/config_exception.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdexcept>
+#include <string>
+
 namespace hocon {
 
     class config_exception : public std::runtime_error {

--- a/lib/inc/internal/objects/simple_config_object.hpp
+++ b/lib/inc/internal/objects/simple_config_object.hpp
@@ -29,11 +29,19 @@ namespace hocon {
          */
         shared_object with_only_path_or_null(path raw_path) const override;
 
+    protected:
+        resolve_result<shared_value>
+            resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
+
     private:
         std::unordered_map<std::string, shared_value> _value;
-        // TODO: Put these back when needed, currently cause an unused error
-//        bool _resolved;
+        resolve_status _resolved;
         bool _ignores_fallbacks;
+
+        std::shared_ptr<simple_config_object> modify(no_exceptions_modifier& modifier) const;
+        std::shared_ptr<simple_config_object> modify_may_throw(modifier& modifier) const;
+
+        struct resolve_modifier;
     };
 
 }  // namespace hocon

--- a/lib/inc/internal/objects/simple_config_object.hpp
+++ b/lib/inc/internal/objects/simple_config_object.hpp
@@ -32,6 +32,7 @@ namespace hocon {
     protected:
         resolve_result<shared_value>
             resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
+        shared_value new_copy(shared_origin) const override;
 
     private:
         std::unordered_map<std::string, shared_value> _value;

--- a/lib/inc/internal/resolve_context.hpp
+++ b/lib/inc/internal/resolve_context.hpp
@@ -1,7 +1,24 @@
 #pragma once
 
+#include <hocon/types.hpp>
+#include <hocon/config_resolve_options.hpp>
+
 namespace hocon {
+
+    class resolve_source;
+
+    template<typename T>
+    struct resolve_result;
+
     // TODO: Implement this class >_>
     class resolve_context {
+    public:
+        bool is_restricted_to_child() const;
+        config_resolve_options options() const;
+
+        resolve_result<shared_value> resolve(shared_value original, resolve_source const& source) const;
+
+    private:
+        config_resolve_options _options;
     };
 }  // namespace hocon

--- a/lib/inc/internal/resolve_result.hpp
+++ b/lib/inc/internal/resolve_result.hpp
@@ -1,15 +1,14 @@
 #pragma once
 #include <internal/resolve_context.hpp>
-#include <memory>
 
 namespace hocon {
 
     template<typename V>
     struct resolve_result {
-        resolve_result(std::shared_ptr<const resolve_context> c, V v) :
+        resolve_result(resolve_context c, V v) :
             context(std::move(c)), value(std::move(v)) {}
 
-        std::shared_ptr<const resolve_context> context;
+        resolve_context context;
         V value;
     };
 

--- a/lib/inc/internal/resolve_source.hpp
+++ b/lib/inc/internal/resolve_source.hpp
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <memory>
+
 namespace hocon {
 
+    class container;
+
     class resolve_source {
+    public:
+        resolve_source push_parent(std::shared_ptr<const container> parent) const;
     };
 }  // namespace hocon

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -48,16 +48,15 @@ namespace hocon {
         iterator end() const { return _value.end(); }
 
         std::shared_ptr<const simple_config_list> concatenate(std::shared_ptr<const simple_config_list> other) const;
-        std::shared_ptr<const config_list> with_origin(shared_origin origin) const override;
 
         bool operator==(simple_config_list const& other) const;
 
     protected:
         resolve_result<shared_value>
             resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
+        shared_value new_copy(shared_origin origin) const override;
 
         void render_list(std::string s, int indent, bool atRoot, std::shared_ptr<config_render_options> options) const;
-        std::shared_ptr<const simple_config_list> new_copy(shared_origin) const {return std::dynamic_pointer_cast<const simple_config_list>(shared_from_this());}
 
     private:
         static const long _serial_version_UID = 2L;

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -56,7 +56,7 @@ namespace hocon {
             resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
         shared_value new_copy(shared_origin origin) const override;
 
-        void render_list(std::string s, int indent, bool atRoot, std::shared_ptr<config_render_options> options) const;
+        void render(std::string& result, int indent, bool at_root, config_render_options options) const override;
 
     private:
         static const long _serial_version_UID = 2L;

--- a/lib/inc/internal/simple_config_list.hpp
+++ b/lib/inc/internal/simple_config_list.hpp
@@ -4,12 +4,10 @@
 #include <hocon/config_list.hpp>
 #include <hocon/config_render_options.hpp>
 #include <internal/container.hpp>
-#include <internal/resolve_result.hpp>
-#include <internal/resolve_context.hpp>
-#include <internal/resolve_source.hpp>
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include <boost/optional.hpp>
 
 namespace hocon {
 
@@ -29,15 +27,12 @@ namespace hocon {
         shared_value replace_child(shared_value const& child, shared_value replacement) const override;
         bool has_descendant(shared_value const& descendant) const override;
 
-        resolve_result<std::shared_ptr<const simple_config_list>>
-            resolve_substitutions(std::shared_ptr<resolve_context> context, std::shared_ptr<resolve_source> source) const;
         std::shared_ptr<const simple_config_list> relativized(const std::string prefix) const;
 
         bool contains(shared_value v) const { return std::find(_value.begin(), _value.end(), v) != _value.end(); }
         bool contains_all(std::vector<shared_value>) const;
         shared_value get(int index) const { return _value[index]; }
 
-        // YOLO
         int index_of(shared_value v) {
             auto pos = find(_value.begin(), _value.end(), v);
             if (pos == _value.end()) {
@@ -47,8 +42,7 @@ namespace hocon {
             }
         }
 
-
-        bool is_empty() const {return _value.empty();}
+        bool is_empty() const { return _value.empty(); }
         int size() const { return _value.size(); }
         iterator begin() const { return _value.begin(); }
         iterator end() const { return _value.end(); }
@@ -59,6 +53,9 @@ namespace hocon {
         bool operator==(simple_config_list const& other) const;
 
     protected:
+        resolve_result<shared_value>
+            resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
+
         void render_list(std::string s, int indent, bool atRoot, std::shared_ptr<config_render_options> options) const;
         std::shared_ptr<const simple_config_list> new_copy(shared_origin) const {return std::dynamic_pointer_cast<const simple_config_list>(shared_from_this());}
 
@@ -67,19 +64,13 @@ namespace hocon {
         const std::vector<shared_value> _value;
         const resolve_status _resolved;
 
-        std::shared_ptr<const simple_config_list> modify(std::shared_ptr<no_exceptions_modifier> modifier, resolve_status new_resolve_status) const;
-        std::shared_ptr<const simple_config_list> modify_may_throw(std::shared_ptr<modifier> modifier, resolve_status new_resolve_status) const;
+        std::shared_ptr<const simple_config_list>
+        modify(no_exceptions_modifier& modifier, boost::optional<resolve_status> new_resolve_status) const;
 
-        class resolve_modifier : public modifier {
-        public:
-            resolve_modifier(std::shared_ptr<resolve_context> context, std::shared_ptr<resolve_source> source);
-            shared_value modify_child_may_throw(std::string key, shared_value v) const override;
+        std::shared_ptr<const simple_config_list>
+        modify_may_throw(modifier& modifier, boost::optional<resolve_status> new_resolve_status) const;
 
-        private:
-            std::vector<shared_value> _value;
-            const std::shared_ptr<resolve_source> _source;
-            std::shared_ptr<resolve_context> _context;
-        };
+        struct resolve_modifier;
     };
 
 }   // namespace hocon

--- a/lib/inc/internal/simple_config_origin.hpp
+++ b/lib/inc/internal/simple_config_origin.hpp
@@ -21,7 +21,8 @@ namespace hocon {
 
         int line_number() const override;
 
-        std::string description() const override;
+        std::string const& description() const override;
+        std::vector<std::string> const& comments() const override;
 
         /**
          * Returns a pointer to a copy of this origin with the specified line number

--- a/lib/inc/internal/values/config_boolean.hpp
+++ b/lib/inc/internal/values/config_boolean.hpp
@@ -13,6 +13,9 @@ namespace hocon {
 
         bool bool_value() const;
 
+    protected:
+        shared_value new_copy(shared_origin) const override;
+
     private:
         bool _value;
     };

--- a/lib/inc/internal/values/config_double.hpp
+++ b/lib/inc/internal/values/config_double.hpp
@@ -16,6 +16,9 @@ namespace hocon {
         int64_t long_value() const override;
         double double_value() const override;
 
+    protected:
+        shared_value new_copy(shared_origin) const override;
+
     private:
         double _value;
     };

--- a/lib/inc/internal/values/config_int.hpp
+++ b/lib/inc/internal/values/config_int.hpp
@@ -13,6 +13,9 @@ namespace hocon {
         int64_t long_value() const override;
         double double_value() const override;
 
+    protected:
+        shared_value new_copy(shared_origin) const override;
+
     private:
         int _value;
     };

--- a/lib/inc/internal/values/config_long.hpp
+++ b/lib/inc/internal/values/config_long.hpp
@@ -16,6 +16,9 @@ namespace hocon {
         int64_t long_value() const override;
         double double_value() const override;
 
+    protected:
+        shared_value new_copy(shared_origin) const override;
+
     private:
         int64_t _value;
     };

--- a/lib/inc/internal/values/config_null.hpp
+++ b/lib/inc/internal/values/config_null.hpp
@@ -20,6 +20,9 @@ namespace hocon {
 
         config_value_type value_type() const override;
         std::string transform_to_string() const override;
+
+    protected:
+        shared_value new_copy(shared_origin) const override;
     };
 
 }  // namespace hocon

--- a/lib/inc/internal/values/config_number.hpp
+++ b/lib/inc/internal/values/config_number.hpp
@@ -30,7 +30,7 @@ namespace hocon {
         static std::shared_ptr<config_number> new_number(
                 shared_origin origin, double value, std::string original_text);
 
-    private:
+    protected:
         std::string _original_text;
     };
 

--- a/lib/inc/internal/values/config_string.hpp
+++ b/lib/inc/internal/values/config_string.hpp
@@ -15,6 +15,9 @@ namespace hocon {
 
         bool was_quoted() const;
 
+    protected:
+        shared_value new_copy(shared_origin) const override;
+
     private:
         std::string _text;
         config_string_type _quoted;

--- a/lib/src/config_delayed_merge.cc
+++ b/lib/src/config_delayed_merge.cc
@@ -27,5 +27,9 @@ namespace hocon {
         return _stack;
     }
 
+    shared_value config_delayed_merge::new_copy(shared_origin origin) const {
+        return make_shared<config_delayed_merge>(move(origin), _stack);
+    }
+
 }  // namespace hocon::config_delayed_merge
 

--- a/lib/src/config_delayed_merge_object.cc
+++ b/lib/src/config_delayed_merge_object.cc
@@ -33,6 +33,11 @@ namespace hocon {
         return {};
     }
 
+    shared_value config_delayed_merge_object::new_copy(shared_origin origin) const {
+        // TODO
+        throw config_exception("config_delayed_merge_object::new_copy not implemented");
+    }
+
     shared_value config_delayed_merge_object::attempt_peek_with_partial_resolve(string const& key) const {
         // TODO
         return {};

--- a/lib/src/config_parser.cc
+++ b/lib/src/config_parser.cc
@@ -44,8 +44,9 @@ namespace hocon { namespace config_parser {
                     if (last_was_newline && !result) {
                         comments.clear();
                     } else if (result) {
-                        // TODO
-                        // result = result->with_origin(result->origin()->append_comments(move(comments)));
+                        auto origin = dynamic_pointer_cast<const simple_config_origin>(result->origin());
+                        assert(origin);
+                        result = result->with_origin(origin->append_comments(move(comments)));
                         break;
                     }
                     last_was_newline = true;

--- a/lib/src/config_render_options.cc
+++ b/lib/src/config_render_options.cc
@@ -13,7 +13,7 @@ namespace hocon {
         return config_render_options(value, _comments, _formatted, _json);
     }
 
-    bool config_render_options::get_origin_comments() {
+    bool config_render_options::get_origin_comments() const {
         return _origin_comments;
     }
 
@@ -21,7 +21,7 @@ namespace hocon {
         return config_render_options(_origin_comments, value, _formatted, _json);
     }
 
-    bool config_render_options::get_comments() {
+    bool config_render_options::get_comments() const {
         return _comments;
     }
 
@@ -29,7 +29,7 @@ namespace hocon {
         return config_render_options(_origin_comments, _comments, value, _json);
     }
 
-    bool config_render_options::get_formatted() {
+    bool config_render_options::get_formatted() const {
         return _formatted;
     }
 
@@ -37,7 +37,7 @@ namespace hocon {
         return config_render_options(_origin_comments, _comments, _formatted, value);
     }
 
-    bool config_render_options::get_json() {
+    bool config_render_options::get_json() const {
         return _json;
     }
 

--- a/lib/src/objects/simple_config_object.cc
+++ b/lib/src/objects/simple_config_object.cc
@@ -133,8 +133,11 @@ namespace hocon {
             new_map.emplace(key, value);
         }
 
-        // TODO: the resolved arugment is incorrect, fix when implementing resolve functionality
-        return make_shared<simple_config_object>(origin(), new_map, resolve_status::RESOLVED, _ignores_fallbacks);
+        return make_shared<simple_config_object>(origin(), new_map, _resolved, _ignores_fallbacks);
+    }
+
+    shared_value simple_config_object::new_copy(shared_origin origin) const {
+        return make_shared<simple_config_object>(move(origin), _value, _resolved, _ignores_fallbacks);
     }
 
     resolve_result<shared_value>

--- a/lib/src/objects/simple_config_object.cc
+++ b/lib/src/objects/simple_config_object.cc
@@ -2,19 +2,39 @@
 #include <hocon/config_value.hpp>
 #include <internal/config_exception.hpp>
 #include <internal/simple_config_origin.hpp>
+#include <internal/resolve_context.hpp>
+#include <internal/resolve_source.hpp>
+#include <internal/resolve_result.hpp>
+#include <internal/container.hpp>
 
 using namespace std;
 
 namespace hocon {
 
+    struct simple_config_object::resolve_modifier : public modifier {
+        // TODO: initialize origin_restrict
+        resolve_modifier(resolve_context c, resolve_source s) : context(move(c)), source(move(s)), origin_restrict("") {}
+
+        shared_value modify_child_may_throw(string key, shared_value v) override
+        {
+            // TODO: implement
+            return {};
+        }
+
+        resolve_context context;
+        resolve_source source;
+        string origin_restrict;
+    };
+
     simple_config_object::simple_config_object(shared_origin origin,
                                                unordered_map <std::string, shared_value> value,
                                                resolve_status status, bool ignores_fallbacks) :
-        config_object(move(origin)), _value(move(value)), _ignores_fallbacks(ignores_fallbacks) { }
+        config_object(move(origin)), _value(move(value)), _resolved(status), _ignores_fallbacks(ignores_fallbacks)
+    {}
 
-        shared_value simple_config_object::attempt_peek_with_partial_resolve(std::string const& key) const {
-            return _value.at(key);
-        }
+    shared_value simple_config_object::attempt_peek_with_partial_resolve(std::string const& key) const {
+        return _value.at(key);
+    }
 
     bool simple_config_object::is_empty() const {
         return _value.empty();
@@ -115,6 +135,31 @@ namespace hocon {
 
         // TODO: the resolved arugment is incorrect, fix when implementing resolve functionality
         return make_shared<simple_config_object>(origin(), new_map, resolve_status::RESOLVED, _ignores_fallbacks);
+    }
+
+    resolve_result<shared_value>
+    simple_config_object::resolve_substitutions(resolve_context const& context, resolve_source const& source) const
+    {
+        if (_resolved == resolve_status::RESOLVED) {
+            return resolve_result<shared_value>(context, shared_from_this());
+        }
+
+        resolve_source source_with_parent = source.push_parent(dynamic_pointer_cast<const container>(shared_from_this()));
+
+        resolve_modifier modifier{context, move(source_with_parent)};
+        auto value = modify_may_throw(modifier);
+        return resolve_result<shared_value>(modifier.context, value);
+    }
+
+    shared_ptr<simple_config_object> simple_config_object::modify(no_exceptions_modifier& modifier) const
+    {
+        return modify_may_throw(modifier);
+    }
+
+    shared_ptr<simple_config_object> simple_config_object::modify_may_throw(modifier& modifier) const
+    {
+        // TODO: implement
+        return {};
     }
 
 }  // namespace hocon

--- a/lib/src/resolve_context.cc
+++ b/lib/src/resolve_context.cc
@@ -1,0 +1,25 @@
+#include <internal/config_exception.hpp>
+#include <internal/resolve_context.hpp>
+#include <internal/resolve_result.hpp>
+#include <internal/resolve_source.hpp>
+
+namespace hocon {
+
+    bool resolve_context::is_restricted_to_child() const
+    {
+        // TODO: implement
+        throw config_exception("resolve_context::is_restricted_to_child is not yet implemented");
+    }
+
+    config_resolve_options resolve_context::options() const
+    {
+        return _options;
+    }
+
+    resolve_result<shared_value> resolve_context::resolve(shared_value original, resolve_source const& source) const
+    {
+        // TODO: implement
+        throw config_exception("resolve_context::resolve is not yet implemented");
+    }
+
+}  // namespace hocon

--- a/lib/src/resolve_source.cc
+++ b/lib/src/resolve_source.cc
@@ -1,0 +1,14 @@
+#include <internal/resolve_source.hpp>
+#include <internal/config_exception.hpp>
+
+namespace hocon {
+
+    using namespace std;
+
+    resolve_source resolve_source::push_parent(shared_ptr<const container> parent) const
+    {
+        // TODO: implement
+        throw config_exception("resolve_source::push_parent not yet implemented");
+    }
+
+}  // namespace hocon

--- a/lib/src/simple_config_list.cc
+++ b/lib/src/simple_config_list.cc
@@ -83,11 +83,11 @@ namespace hocon {
         return make_shared<simple_config_list>(combined_origin, move(combined));
     }
 
-    std::shared_ptr<const config_list> simple_config_list::with_origin(shared_origin origin) const
+    shared_value simple_config_list::new_copy(shared_origin origin) const
     {
-        // TODO: implement config_value::with_origin
-        // return config_value::with_origin(move(origin));
-        return {};
+        // TODO: Copies the list, but the list is immutable so we could share the vector.
+        //       Best to deal with in a rewrite that encapsulates shared_ptr and immutability better.
+        return make_shared<simple_config_list>(move(origin), _value);
     }
 
     bool simple_config_list::operator==(simple_config_list const& other) const

--- a/lib/src/simple_config_list.cc
+++ b/lib/src/simple_config_list.cc
@@ -1,5 +1,6 @@
 #include <hocon/config_value.hpp>
 #include <internal/simple_config_list.hpp>
+#include <internal/simple_config_origin.hpp>
 #include <internal/config_exception.hpp>
 #include <internal/resolve_context.hpp>
 #include <internal/resolve_source.hpp>
@@ -74,12 +75,12 @@ namespace hocon {
 
     std::shared_ptr<const simple_config_list> simple_config_list::concatenate(shared_ptr<const simple_config_list> other) const
     {
-        // TODO merge origins
+        auto combined_origin = simple_config_origin::merge_origins(origin(), other->origin());
         vector<shared_value> combined;
         combined.reserve(size() + other->size());
         combined.insert(combined.end(), begin(), end());
         combined.insert(combined.end(), other->begin(), other->end());
-        return make_shared<simple_config_list>(origin(), move(combined));
+        return make_shared<simple_config_list>(combined_origin, move(combined));
     }
 
     std::shared_ptr<const config_list> simple_config_list::with_origin(shared_origin origin) const

--- a/lib/src/simple_config_origin.cc
+++ b/lib/src/simple_config_origin.cc
@@ -33,8 +33,12 @@ namespace hocon {
         return _line_number;
     }
 
-    string simple_config_origin::description() const {
+    string const& simple_config_origin::description() const {
         return _description;
+    }
+
+    vector<string> const& simple_config_origin::comments() const {
+        return _comments_or_null;
     }
 
     shared_origin simple_config_origin::with_line_number(int line_number) const {

--- a/lib/src/values/config_boolean.cc
+++ b/lib/src/values/config_boolean.cc
@@ -19,4 +19,8 @@ namespace hocon {
         return _value;
     }
 
+    shared_value config_boolean::new_copy(shared_origin origin) const {
+        return make_shared<config_boolean>(move(origin), _value);
+    }
+
 }  // namespace hocon

--- a/lib/src/values/config_double.cc
+++ b/lib/src/values/config_double.cc
@@ -24,4 +24,8 @@ namespace hocon {
         return _value;
     }
 
+    shared_value config_double::new_copy(shared_origin origin) const {
+        return make_shared<config_double>(move(origin), _value, _original_text);
+    }
+
 }  // namespace hocon

--- a/lib/src/values/config_int.cc
+++ b/lib/src/values/config_int.cc
@@ -24,4 +24,8 @@ namespace hocon {
         return _value;
     }
 
+    shared_value config_int::new_copy(shared_origin origin) const {
+        return make_shared<config_int>(move(origin), _value, _original_text);
+    }
+
 }  // namespace hocon

--- a/lib/src/values/config_long.cc
+++ b/lib/src/values/config_long.cc
@@ -24,4 +24,8 @@ namespace hocon {
         return _value;
     }
 
+    shared_value config_long::new_copy(shared_origin origin) const {
+        return make_shared<config_long>(move(origin), _value, _original_text);
+    }
+
 }  // namespace hocon

--- a/lib/src/values/config_null.cc
+++ b/lib/src/values/config_null.cc
@@ -15,4 +15,8 @@ namespace hocon {
         return "null";
     }
 
+    shared_value config_null::new_copy(shared_origin origin) const {
+        return make_shared<config_null>(move(origin));
+    }
+
 }  // namespace hocon

--- a/lib/src/values/config_string.cc
+++ b/lib/src/values/config_string.cc
@@ -15,6 +15,10 @@ namespace hocon {
         return _text;
     }
 
+    shared_value config_string::new_copy(shared_origin origin) const {
+        return make_shared<config_string>(move(origin), _text, _quoted);
+    }
+
     bool config_string::was_quoted() const {
         return _quoted == config_string_type::QUOTED;
     }

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -79,6 +79,12 @@ namespace hocon {
         result += transform_to_string();
     }
 
+    void config_value::indent(std::string &result, int indent, config_render_options const& options) {
+        if (options.get_formatted()) {
+            result.append(' ', indent*4);
+        }
+    }
+
     shared_config config_value::at_path(shared_origin origin, path raw_path) const {
         path parent = raw_path.parent();
         shared_config result = at_key(origin, *raw_path.last());

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -104,6 +104,14 @@ namespace hocon {
         return at_path(move(origin), path::new_path(path_expression));
     }
 
+    shared_value config_value::with_origin(shared_origin origin) const {
+        if (_origin == origin) {
+            return shared_from_this();
+        } else {
+            return new_copy(move(origin));
+        }
+    }
+
     resolve_result<shared_value>
     config_value::resolve_substitutions(resolve_context const& context,
                                         resolve_source const& source) const

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -6,6 +6,7 @@
 #include <internal/simple_config_origin.hpp>
 #include <internal/container.hpp>
 #include <internal/config_delayed_merge.hpp>
+#include <internal/resolve_result.hpp>
 #include <algorithm>
 
 using namespace std;
@@ -103,6 +104,13 @@ namespace hocon {
         return at_path(move(origin), path::new_path(path_expression));
     }
 
+    resolve_result<shared_value>
+    config_value::resolve_substitutions(resolve_context const& context,
+                                        resolve_source const& source) const
+    {
+        return resolve_result<shared_value>(context, shared_from_this());
+    }
+
     std::vector<shared_value> config_value::replace_child_in_list(std::vector<shared_value> const& values,
                                                                   shared_value const& child, shared_value replacement)
     {
@@ -139,7 +147,7 @@ namespace hocon {
 
     config_value::no_exceptions_modifier::no_exceptions_modifier(string prefix): _prefix(std::move(prefix)) {}
 
-    shared_value config_value::no_exceptions_modifier::modify_child_may_throw(string key_or_null, shared_value v) const {
+    shared_value config_value::no_exceptions_modifier::modify_child_may_throw(string key_or_null, shared_value v) {
         try {
             return modify_child(key_or_null, v);
         } catch (runtime_error& e) {


### PR DESCRIPTION
Implements portions of resolve_substitutions in existing classes
(config_value, simple_config_list, and simple_config_object); with
stubs of methods needed from resolve_context and resolve_source.