### PR TITLE
(HC-42) Add memoization support to resolve_context

### DIFF
--- a/lib/tests/concatenation_test.cc
+++ b/lib/tests/concatenation_test.cc
@@ -12,10 +12,7 @@ TEST_CASE("concatenation") {
         auto conf = parse_config(R"(a :  true "xyz" 123 foo)")->resolve();
         REQUIRE(conf->get_string("a") == "true xyz 123 foo");
     }
-}
 
-// These tests are expected to fail because resolve_result::resolve implementation is incomplete.
-TEST_CASE("concatenation pending", "[!shouldfail]") {
     SECTION("trivial string concatenation") {
         auto conf = parse_config(R"(a : ${x}foo, x = 1)")->resolve();
         REQUIRE(conf->get_string("a") == "1foo");


### PR DESCRIPTION
This is gross and probably super inefficient (lots of copying
unordered_maps around), but mirrors the original pretty closely.