### PR TITLE
(HC-52) Add basic config substitution tests

### DIFF
--- a/lib/src/tokenizer.cc
+++ b/lib/src/tokenizer.cc
@@ -185,10 +185,16 @@ namespace hocon {
     }
 
     /** Characters JSON allows a number to start with */
-    static const string first_number_chars = "0123456789-";
+    static string first_number_chars() {
+        static const string first_number_chars_ = "0123456789-";
+        return first_number_chars_;
+    }
 
     /** Characters allowed in a JSON number */
-    static const string number_chars = "0123456789eE+-.";
+    static string number_chars() {
+        static const string number_chars_ = "0123456789eE+-.";
+        return number_chars_;
+    }
 
     /** Character that stop an unquoted string */
     static const string not_in_unquoted_text = "$\"{}[]:=,+#`^?!@*&\\";
@@ -239,7 +245,7 @@ namespace hocon {
         result += first_char;
         bool contained_decimal_or_E = false;
         char c = next_char_raw();
-        while (c != -1 && number_chars.find(c) != string::npos) {
+        while (c != -1 && number_chars().find(c) != string::npos) {
             if (c == '.' || c == 'e' || c == 'E') {
                 contained_decimal_or_E = true;
             }
@@ -502,7 +508,7 @@ namespace hocon {
                 }
 
                 if (t == nullptr) {
-                    if (first_number_chars.find(c) != string::npos) {
+                    if (first_number_chars().find(c) != string::npos) {
                         t = pull_number(c);
                     } else if (not_in_unquoted_text.find(c) != string::npos) {
                         throw config_exception("Reserved character '" + string(1, c) + "' is not allowed" +

--- a/lib/tests/concatenation_test.cc
+++ b/lib/tests/concatenation_test.cc
@@ -318,7 +318,6 @@ TEST_CASE("Concatenation pending '+=' implementation", "[!shouldfail]") {
             auto conf = parse_config(R"(a = { x : y }, a += 2)")->resolve();
         } catch (const hocon::config_exception& e) {
             thrown = true;
-            printf(e.what());
             REQUIRE_STRING_CONTAINS(e.what(), "Cannot concatenate");
             REQUIRE_STRING_CONTAINS(e.what(), R"("x":"y")");
             REQUIRE_STRING_CONTAINS(e.what(), "[2]");

--- a/lib/tests/config_substitution_test.cc
+++ b/lib/tests/config_substitution_test.cc
@@ -1,36 +1,75 @@
-//#include <catch.hpp>
-//#include "test_utils.hpp"
-//
-//#include <hocon/config.hpp>
-//#include <internal/values/simple_config_object.hpp>
-//
-//#include <internal/resolve_result.hpp>
-//#include <hocon/config_resolve_options.hpp>
-//#include <internal/resolve_context.hpp>
-//
-//using namespace std;
-//using namespace hocon;
-//
-//static auto const simple_object = parse_object(R"(
-//{
-//    "foo" : 42,
-//    "bar" : {
-//        "int" : 43,
-//        "bool" : true,
-//        "null" : null,
-//        "string" : "hello",
-//        "double" : 3.14
-//    }
-//}
-//)");
-//
-//static shared_value resolve_without_fallbacks (shared_value s, shared_object root) {
-//    auto options = config_resolve_options(false);
-//    return resolve_context::resolve(s, root, options);
-//}
+#include <catch.hpp>
+#include "test_utils.hpp"
 
-//TEST_CASE("resolve trivial key") {
-//    auto s = subst("foo");
-//    auto v = resolve_without_fallbacks(s, simple_object);
-//    REQUIRE(int_value(42) == v);
-//}
+#include <hocon/config.hpp>
+#include <internal/values/simple_config_object.hpp>
+
+#include <internal/resolve_result.hpp>
+#include <hocon/config_resolve_options.hpp>
+#include <internal/resolve_context.hpp>
+#include <hocon/config_exception.hpp>
+
+using namespace std;
+using namespace hocon;
+using namespace hocon::test_utils;
+
+static shared_object simple_object() {
+    static auto const resolved = parse_object(R"(
+{
+    "foo" : 42,
+    "bar" : {
+        "int" : 43,
+        "bool" : true,
+        "null" : null,
+        "string" : "hello",
+        "double" : 3.14
+    }
+}
+)");
+
+    return resolved;
+}
+
+static shared_value resolve_without_fallbacks (shared_value s, shared_object root) {
+    auto options = config_resolve_options(false);
+    return resolve_context::resolve(s, root, options);
+}
+
+TEST_CASE("resolve trivial key") {
+    auto s = subst("foo");
+    auto v = resolve_without_fallbacks(s, simple_object());
+    REQUIRE(*int_value(42) == *v);
+}
+
+// the "resolve int" test is exactly the same as
+// "resolve trivial path" so I did not repeat it
+TEST_CASE("resolve trivial path") {
+    auto s = subst("bar.int");
+    auto v = resolve_without_fallbacks(s, simple_object());
+    REQUIRE(*int_value(43) == *v);
+}
+
+TEST_CASE("resolve bool") {
+    auto s = subst("bar.bool");
+    auto v = resolve_without_fallbacks(s, simple_object());
+    REQUIRE(*bool_value(true) == *v);
+}
+
+TEST_CASE("resolve null") {
+    auto s = subst("bar.null");
+    auto v = resolve_without_fallbacks(s, simple_object());
+    REQUIRE(*null_value() == *v);
+}
+
+TEST_CASE("resolve string") {
+    auto s = subst("bar.string");
+    auto v = resolve_without_fallbacks(s, simple_object());
+    REQUIRE(*string_value("hello") == *v);
+}
+
+TEST_CASE("resolve double") {
+    auto s = subst("bar.double");
+    auto v = resolve_without_fallbacks(s, simple_object());
+    REQUIRE(*double_value(3.14) == *v);
+}
+

--- a/lib/tests/test_utils.cc
+++ b/lib/tests/test_utils.cc
@@ -140,6 +140,26 @@ namespace hocon { namespace test_utils {
         return make_shared<config_int>(fake_origin(), i, "");
     }
 
+    shared_ptr<config_boolean> bool_value(bool b) {
+        return make_shared<config_boolean>(fake_origin(), b);
+    }
+
+    shared_ptr<config_null> null_value() {
+        return make_shared<config_null>(fake_origin());
+    }
+
+    shared_ptr<config_string> string_value(string s) {
+        return make_shared<config_string>(fake_origin(), s, config_string_type::QUOTED);
+    }
+
+    shared_ptr<config_double> double_value(double d) {
+        return make_shared<config_double>(fake_origin(), d, "");
+    }
+
+    shared_ptr<config_reference> subst(string ref, bool optional) {
+        return make_shared<config_reference>(fake_origin(), make_shared<substitution_expression>(path::new_path(ref), optional));
+    }
+
     /** Paths */
     path test_path(initializer_list<string> path_strings) {
         return path(vector<string> { path_strings });

--- a/lib/tests/test_utils.hpp
+++ b/lib/tests/test_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <internal/simple_config_origin.hpp>
+#include <internal/substitution_expression.hpp>
 #include <internal/tokens.hpp>
 #include <internal/values/config_string.hpp>
 #include <internal/values/config_boolean.hpp>
@@ -8,6 +9,7 @@
 #include <internal/values/config_long.hpp>
 #include <internal/values/config_int.hpp>
 #include <internal/values/config_null.hpp>
+#include <internal/values/config_reference.hpp>
 #include <internal/nodes/config_node_simple_value.hpp>
 
 #include <string>
@@ -93,6 +95,16 @@ namespace hocon { namespace test_utils {
     // make the test compare public API to itself.
     std::shared_ptr<config_int> int_value(int i);
     // TODO: remaining value helpers
+
+    std::shared_ptr<config_boolean> bool_value(bool b);
+
+    std::shared_ptr<config_null> null_value();
+
+    std::shared_ptr<config_string> string_value(std::string s);
+
+    std::shared_ptr<config_double> double_value(double d);
+
+    std::shared_ptr<config_reference> subst(std::string ref, bool optional = false);
 
     /** Paths */
     path test_path(std::initializer_list<std::string> path_elements);


### PR DESCRIPTION
Add some basic tests for substitution and the relevant helper methods.
Also do a bit of code cleanup including making the needed operators
public and replacing some global instance variables with functions
instead (to avoid and error where the variable is not initialized
at the time the tests are run).