### PR TITLE
(HC-60) Finish simple_config_object implementation

### DIFF
--- a/lib/inc/internal/values/simple_config_object.hpp
+++ b/lib/inc/internal/values/simple_config_object.hpp
@@ -64,6 +64,12 @@ namespace hocon {
          */
         std::vector<std::string> key_set() const;
 
+        /**
+         * Construct a list of the values from the provided map.
+         * Equivalent to Java's Collection.values() method.
+         */
+        std::vector<shared_value> value_set(std::unordered_map<std::string, shared_value> m) const;
+
         bool operator==(config_value const& other) const override;
 
         static std::shared_ptr<simple_config_object> empty();

--- a/lib/src/values/simple_config_object.cc
+++ b/lib/src/values/simple_config_object.cc
@@ -105,10 +105,10 @@ namespace hocon {
         if (object && !next.empty()) {
             auto value = object->without_path(next);
             unordered_map<string, shared_value> updated { make_pair(key, value) };
-            // TODO: the last argument is incorrect, fix when implementing resolve functionality
-
-
-            return make_shared<simple_config_object>(origin(), updated, resolve_status::RESOLVED, _ignores_fallbacks);
+            return make_shared<simple_config_object>(origin(),
+                                                     updated,
+                                                     resolve_status_from_values(value_set(updated)),
+                                                     _ignores_fallbacks);
         } else if (!next.empty() || v == _value.end()) {
             return dynamic_pointer_cast<const config_object>(shared_from_this());
         } else {
@@ -118,8 +118,10 @@ namespace hocon {
                     smaller.emplace(old);
                 }
             }
-            // TODO: the last argument is incorrect, fix when implementing resolve functionality
-            return make_shared<simple_config_object>(origin(), smaller);
+            return make_shared<simple_config_object>(origin(),
+                                                     smaller,
+                                                     resolve_status_from_values(value_set(smaller)),
+                                                     _ignores_fallbacks);
         }
     }
 


### PR DESCRIPTION
These commits implement `simple_config_object::replace_child` and `simple_config_object::has_descendant`, in addition to fixing a few TODOs.