### PR TITLE
(HC-68) Finish config_parser::parse_object

### DIFF
--- a/lib/inc/internal/replaceable_merge_stack.hpp
+++ b/lib/inc/internal/replaceable_merge_stack.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <internal/resolve_context.hpp>
+#include <internal/container.hpp>
 
 namespace hocon {
 
     // This is a faithful port of the Java ReplaceableMergeStack interface
-    class replaceable_merge_stack {
+    class replaceable_merge_stack : public container {
     public:
         virtual shared_value make_replacement(resolve_context const& context, int skipping) const = 0;
     };

--- a/lib/inc/internal/resolve_source.hpp
+++ b/lib/inc/internal/resolve_source.hpp
@@ -25,6 +25,10 @@ namespace hocon {
         resolve_source push_parent(std::shared_ptr<const container> parent) const;
         result_with_path lookup_subst(resolve_context context, std::shared_ptr<substitution_expression> subst, int prefix_length) const;
 
+        resolve_source replace_current_parent(std::shared_ptr<const container> old, std::shared_ptr<const container> replacement) const;
+        resolve_source replace_within_current_parent(shared_value old, shared_value replacement) const;
+        resolve_source reset_parents() const;
+
     private:
         struct value_with_path {
             shared_value value;
@@ -37,5 +41,9 @@ namespace hocon {
         value_with_path find_in_object(shared_object obj, path the_path) const;
         result_with_path find_in_object(shared_object obj, resolve_context context, path the_path) const;
         value_with_path find_in_object(shared_object obj, path the_path, node parents) const;
+
+        shared_object root_must_be_obj(std::shared_ptr<const container> value) const;
+
+        static node replace(const node& list, std::shared_ptr<const container> old, shared_value replacement);
     };
 }  // namespace hocon

--- a/lib/inc/internal/values/config_delayed_merge.hpp
+++ b/lib/inc/internal/values/config_delayed_merge.hpp
@@ -22,9 +22,14 @@ namespace hocon {
 
         std::vector<shared_value> unmerged_values() const override;
 
+        resolve_result<shared_value> resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
+        static resolve_result<shared_value> resolve_substitutions(std::shared_ptr<const replaceable_merge_stack> replaceable, const std::vector<shared_value>& _stack, resolve_context const& context, resolve_source const& source);
         resolve_status get_resolve_status() const override { return resolve_status::UNRESOLVED; }
 
         bool operator==(config_value const& other) const override;
+
+        shared_value replace_child(shared_value const& child, shared_value replacement) const override;
+        bool has_descendant(shared_value const& descendant) const override;
 
     protected:
         shared_value new_copy(shared_origin) const override;

--- a/lib/inc/internal/values/config_delayed_merge_object.hpp
+++ b/lib/inc/internal/values/config_delayed_merge_object.hpp
@@ -27,6 +27,11 @@ namespace hocon {
 
         bool operator==(config_value const& other) const override;
 
+        // container interface
+        shared_value replace_child(shared_value const& child, shared_value replacement) const override;
+        bool has_descendant(shared_value const& descendant) const override;
+
+
     protected:
         shared_value attempt_peek_with_partial_resolve(std::string const& key) const override;
         std::unordered_map<std::string, shared_value> const& entry_set() const override;

--- a/lib/src/config_parser.cc
+++ b/lib/src/config_parser.cc
@@ -3,6 +3,7 @@
 #include <hocon/config_object.hpp>
 #include <internal/tokens.hpp>
 #include <internal/simple_includer.hpp>
+#include <internal/substitution_expression.hpp>
 #include <internal/nodes/config_node_comment.hpp>
 #include <internal/nodes/config_node_complex_value.hpp>
 #include <internal/nodes/config_node_simple_value.hpp>
@@ -12,6 +13,7 @@
 #include <internal/nodes/config_node_field.hpp>
 #include <internal/nodes/config_node_include.hpp>
 #include <internal/values/config_concatenation.hpp>
+#include <internal/values/config_reference.hpp>
 #include <internal/values/simple_config_object.hpp>
 #include <internal/values/simple_config_list.hpp>
 
@@ -188,8 +190,12 @@ namespace hocon { namespace config_parser {
                     array_count -= 1;
 
                     vector<shared_value> concat;
-                    // TODO: add config_reference and do concatenation
-                    throw bug_or_broken_exception("portion of parse_object is unimplemented");
+                    concat.reserve(2);
+                    auto previous_ref = make_shared<config_reference>(new_value->origin(), make_shared<substitution_expression>(full_current_path(), true));
+                    auto list = make_shared<simple_config_list>(new_value->origin(), vector<shared_value>({new_value}));
+                    concat.push_back(previous_ref);
+                    concat.push_back(list);
+                    new_value = config_concatenation::concatenate(concat);
                 }
 
                 // Grab any trailing comments on the same line

--- a/lib/src/values/config_delayed_merge.cc
+++ b/lib/src/values/config_delayed_merge.cc
@@ -2,6 +2,10 @@
 #include <internal/values/config_delayed_merge_object.hpp>
 #include <hocon/config_exception.hpp>
 
+#include <internal/resolve_context.hpp>
+#include <internal/resolve_result.hpp>
+#include <internal/resolve_source.hpp>
+
 using namespace std;
 
 namespace hocon {
@@ -52,6 +56,58 @@ namespace hocon {
         return _stack;
     }
 
+    resolve_result<shared_value> config_delayed_merge::resolve_substitutions(resolve_context const& context, resolve_source const& source) const {
+        return resolve_substitutions(dynamic_pointer_cast<const replaceable_merge_stack>(shared_from_this()), _stack, context, source);
+    }
+
+    resolve_result<shared_value> config_delayed_merge::resolve_substitutions(shared_ptr<const replaceable_merge_stack> replaceable, vector<shared_value> const& stack, resolve_context const& context, resolve_source const& source) {
+        // TODO add tracing/logging
+
+        resolve_context new_context = context;
+        int count = 0;
+        shared_value merged;
+
+        for (const auto& end : stack) {
+            resolve_source source_for_end = source;
+
+            if (dynamic_pointer_cast<const replaceable_merge_stack>(end)) {
+                throw bug_or_broken_exception("A delayed merge should not contain another one");
+            } else if (dynamic_pointer_cast<const unmergeable>(end)) {
+                shared_value remainder = replaceable->make_replacement(context, count+1);
+
+                // TODO more tracing
+
+                source_for_end = source.replace_within_current_parent(dynamic_pointer_cast<const config_value>(replaceable), remainder);
+
+                // TODO more tracing
+
+                source_for_end = source_for_end.reset_parents();
+            } else {
+                source_for_end = source.push_parent(replaceable);
+            }
+
+            // TODO tracing
+
+            auto result = new_context.resolve(end, source_for_end);
+            auto resolved_end = result.value;
+            new_context = result.context;
+
+            if (resolved_end) {
+                if (!merged) {
+                    merged = resolved_end;
+                } else {
+                    // TODO tracing
+                    merged = dynamic_pointer_cast<const config_value>(merged->with_fallback(resolved_end));
+                }
+            }
+
+            count++;
+
+            // TOOD tracing
+        }
+        return make_resolve_result(new_context, merged);
+    }
+
     shared_value config_delayed_merge::new_copy(shared_origin origin) const {
         return make_shared<config_delayed_merge>(move(origin), _stack);
     }
@@ -59,6 +115,22 @@ namespace hocon {
     bool config_delayed_merge::operator==(config_value const& other) const {
         return equals<config_delayed_merge>(other, [&](config_delayed_merge const& o) { return _stack == o._stack; });
     }
+
+    shared_value config_delayed_merge::replace_child(shared_value const& child, shared_value replacement) const
+    {
+        auto new_stack = replace_child_in_list(_stack, child, move(replacement));
+        if (new_stack.empty()) {
+             return nullptr;
+        } else {
+            return make_shared<config_delayed_merge>(origin(), new_stack);
+        }
+    }
+
+    bool config_delayed_merge::has_descendant(shared_value const& descendant) const
+    {
+        return has_descendant_in_list(_stack, descendant);
+    }
+
 
     bool config_delayed_merge::ignores_fallbacks() const {
         return _stack.back()->ignores_fallbacks();

--- a/lib/src/values/config_delayed_merge_object.cc
+++ b/lib/src/values/config_delayed_merge_object.cc
@@ -73,4 +73,19 @@ namespace hocon {
         return not_resolved_exception("need to config::resolve() before using this object, see the API docs for config::resolve()");
     }
 
+    shared_value config_delayed_merge_object::replace_child(shared_value const& child, shared_value replacement) const
+    {
+        auto new_stack = replace_child_in_list(_stack, child, move(replacement));
+        if (new_stack.empty()) {
+             return nullptr;
+        } else {
+            return make_shared<config_delayed_merge>(origin(), new_stack);
+        }
+    }
+
+    bool config_delayed_merge_object::has_descendant(shared_value const& descendant) const
+    {
+        return has_descendant_in_list(_stack, descendant);
+    }
+
 }  // namespace hocon

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -278,7 +278,8 @@ namespace hocon {
         // if we contain a substitution, resolving it may need to look
         // back to the fallback.
         stack.push_back(move(fallback));
-        return construct_delayed_merge(config_object::merge_origins(stack), move(stack));
+        auto merged = config_object::merge_origins(stack);
+        return construct_delayed_merge(merged, move(stack));
     }
 
 }  // namespace hocon

--- a/lib/tests/test_utils.cc
+++ b/lib/tests/test_utils.cc
@@ -381,11 +381,10 @@ namespace hocon { namespace test_utils {
         parse_test(R"([ ${"foo""bar"} ])"), // multiple strings in substitution
         parse_test(R"([ ${foo  "bar"  baz} ])"), // multiple strings and whitespace in substitution
         parse_test("[${true}]"), // substitution with unquoted true token
-        // TODO: portion of parse_object is unimplemented
-        // parse_test("a = [], a += b"), // += operator with previous init
-        // parse_test("{ a = [], a += 10 }"), // += in braces object with previous init
-        // parse_test("a += b"), // += operator without previous init
-        // parse_test("{ a += 10 }"), // += in braces object without previous init
+        parse_test("a = [], a += b"), // += operator with previous init
+        parse_test("{ a = [], a += 10 }"), // += in braces object with previous init
+        parse_test("a += b"), // += operator without previous init
+        parse_test("{ a += 10 }"), // += in braces object without previous init
         parse_test("[ 10e3e3 ]"), // two exponents. this should parse to a number plus string "e3"
         parse_test("[ 1-e3 ]"), // malformed number should end up as a string instead
         parse_test("[ 1.0.0 ]"), // two decimals, should end up as a string


### PR DESCRIPTION
This finishes up the work on config_parser::parse_object. Also included is the resolve_substitutions for config_delayed_merge, which was necessary to finish this work.