### PR TITLE
(maint) Fixed a couple of misused moves.

### DIFF
--- a/lib/src/resolve_context.cc
+++ b/lib/src/resolve_context.cc
@@ -13,7 +13,7 @@ namespace hocon {
          : _options(move(options)), _restrict_to_child(move(restrict_to_child)), _cycle_markers(move(cycle_markers)) { }
 
     resolve_context::resolve_context(config_resolve_options options, path restrict_to_child)
-         : resolve_context(move(options), move(restrict_to_child), move(vector<shared_value> {})) { }
+         : resolve_context(move(options), move(restrict_to_child), vector<shared_value> {}) { }
 
     bool resolve_context::is_restricted_to_child() const
     {

--- a/lib/src/simple_includer.cc
+++ b/lib/src/simple_includer.cc
@@ -54,7 +54,7 @@ namespace hocon {
     }
 
     shared_object simple_includer::include_file_without_fallback(shared_include_context context, std::string what) {
-        return config::parse_file_any_syntax(move(what), move(context->parse_options()))->root();
+        return config::parse_file_any_syntax(move(what), context->parse_options())->root();
     }
 
     config_parse_options simple_includer::clear_for_include(config_parse_options const& options) {


### PR DESCRIPTION
When attempting to compile on my system, both of these moves caused the error "moving a temporary object prevents copy elision." After removing the offending moves, the project compiles and all the tests pass.