### PR TITLE
(HC-59) Finish config_delayed_merge_object implementation

### DIFF
--- a/lib/inc/hocon/config_object.hpp
+++ b/lib/inc/hocon/config_object.hpp
@@ -13,6 +13,7 @@ namespace hocon {
         friend class config_value;
         friend class simple_config_object;
         friend class resolve_source;
+        friend class config_delayed_merge_object;
     public:
         /**
          * Converts this object to a {@link Config} instance, enabling you to use
@@ -43,6 +44,10 @@ namespace hocon {
         virtual shared_value attempt_peek_with_partial_resolve(std::string const& key) const = 0;
         shared_value peek_path(path desired_path) const;
         shared_value peek_assuming_resolved(std::string const& key, path original_path) const;
+
+        virtual shared_object new_copy(resolve_status const& status, shared_origin origin) const = 0;
+        shared_value new_copy(shared_origin origin) const override;
+
         shared_value construct_delayed_merge(shared_origin origin, std::vector<shared_value> stack) const override;
 
         virtual std::unordered_map<std::string, shared_value> const& entry_set() const = 0;

--- a/lib/inc/internal/values/config_delayed_merge_object.hpp
+++ b/lib/inc/internal/values/config_delayed_merge_object.hpp
@@ -38,7 +38,7 @@ namespace hocon {
         shared_object without_path(path raw_path) const override;
         shared_object with_only_path(path raw_path) const override;
         shared_object with_only_path_or_null(path raw_path) const override;
-        shared_value new_copy(shared_origin origin) const override;
+        shared_object new_copy(resolve_status const& status, shared_origin origin) const override;
         bool ignores_fallbacks() const override;
 
     private:

--- a/lib/inc/internal/values/simple_config_object.hpp
+++ b/lib/inc/internal/values/simple_config_object.hpp
@@ -86,6 +86,7 @@ namespace hocon {
         resolve_status _resolved;
         bool _ignores_fallbacks;
 
+        shared_object new_copy(resolve_status const& new_status, shared_origin new_origin) const override;
         std::shared_ptr<simple_config_object> modify(no_exceptions_modifier& modifier) const;
         std::shared_ptr<simple_config_object> modify_may_throw(modifier& modifier) const;
 

--- a/lib/src/values/config_delayed_merge_object.cc
+++ b/lib/src/values/config_delayed_merge_object.cc
@@ -1,5 +1,6 @@
 #include <internal/values/config_delayed_merge_object.hpp>
 #include <internal/values/config_delayed_merge.hpp>
+#include <internal/values/simple_config_list.hpp>
 #include <hocon/config_exception.hpp>
 
 using namespace std;
@@ -35,14 +36,90 @@ namespace hocon {
         throw not_resolved();
     }
 
-    shared_value config_delayed_merge_object::new_copy(shared_origin origin) const {
-        // TODO
-        throw config_exception("config_delayed_merge_object::new_copy not implemented");
+    shared_object config_delayed_merge_object::new_copy(resolve_status const& status, shared_origin origin) const {
+        if (status != get_resolve_status()) {
+            throw bug_or_broken_exception("attempt to create resolved config_delayted_merge_object");
+        }
+        return make_shared<config_delayed_merge_object>(move(origin), _stack);
     }
 
     shared_value config_delayed_merge_object::attempt_peek_with_partial_resolve(string const& key) const {
-        // TODO
-        throw config_exception("config_delayed_merge_object::attempt_peek_with_partial_resolve not implemented");
+        /* a partial resolve of a ConfigDelayedMergeObject always results in a
+         * SimpleConfigObject because all the substitutions in the stack get
+         * resolved in order to look up the partial.
+         * So we know here that we have not been resolved at all even
+         * partially.
+         * Given that, all this code is probably gratuitous, since the app code
+         * is likely broken. But in general we only throw NotResolved if you try
+         * to touch the exact key that isn't resolved, so this is in that
+         * spirit
+         */
+
+        // we'll be able to return a key if we have a value that ignores
+        // fallbacks, prior to any unmergeable values.
+        for (auto&& layer : _stack) {
+            if (auto object_layer = dynamic_pointer_cast<const config_object>(layer)) {
+                auto v = object_layer->attempt_peek_with_partial_resolve(key);
+                if (v != nullptr) {
+                    if (v->ignores_fallbacks()) {
+                        // we know we won't need to merge anything in to this value
+                        return v;
+                    } else {
+                        /* we can't return this value because we know there are
+                         * unmergeable values later in the stack that may
+                         * contain values that need to be merged with this
+                         * value. we'll throw the exception when we get to those
+                         * unmergeable values, so continue here.
+                         */
+                        continue;
+                    }
+                } else if (dynamic_pointer_cast<const unmergeable>(layer)) {
+                    /* an unmergeable object (which would be another
+                     * config_delayed_merge_object) can't know that a key is
+                     * missing, so it can't return null; it can only return a
+                     * value or throw not_possible_to_resolve
+                     */
+                    throw bug_or_broken_exception("should not be reached: unmergeable object returned null value");
+                } else {
+                    /* a non-unmergeable config_objeect that returned null
+                     * for the key in question is not relevant, we can keep
+                     * looking for a value.
+                     */
+                    continue;
+                }
+            } else if (dynamic_pointer_cast<const unmergeable>(layer)) {
+                throw not_resolved_exception("Key '" + key + "' is not available at '" + origin()->description()
+                                             + "'because value at '" + layer->origin()->description()
+                                             + "' has not been resolved and may turn out to contain or hide '"
+                                             + key + "'. Be sure to config::resolve() before using a config object");
+            } else if (layer->get_resolve_status() == resolve_status::UNRESOLVED) {
+                /* if the layer is not an object, and not a substitution or
+                 * merge, then it's something that's unresolved because it _contains_
+                 * an unresolved object... i.e. it's an array
+                 */
+                if (!dynamic_pointer_cast<const simple_config_list>(layer)) {
+                    throw bug_or_broken_exception("Expecting a list here, not " + layer->render());
+                    // all later objects will be hidden so we can say we won't find the key
+                    return nullptr;
+                }
+            } else {
+                /* non-object, but resolved, like an integer or something.
+                 * has no children so the one we're after won't be in it.
+                 * we would only have this in the stack in case something
+                 * else "looks back" to it due to a cycle.
+                 * anyway at this point we know we can't find the key anymore.
+                 */
+                if (!layer->ignores_fallbacks()) {
+                    throw bug_or_broken_exception("resolved non-object should ignore fallbacks");
+                }
+                return nullptr;
+            }
+        }
+        /* If we get here, then we never found anything unresolved which means
+         * the ConfigDelayedMergeObject should not have existed. some
+         * invariant was violated.
+         */
+        throw bug_or_broken_exception("Delayed merge stack does not contain any unmergeable values");
     }
 
     unordered_map<string, shared_value> const& config_delayed_merge_object::entry_set() const {

--- a/lib/src/values/config_object.cc
+++ b/lib/src/values/config_object.cc
@@ -44,6 +44,10 @@ namespace hocon {
         }
     }
 
+    shared_value config_object::new_copy(shared_origin origin) const {
+        return new_copy(get_resolve_status(), origin);
+    }
+
     shared_value config_object::construct_delayed_merge(shared_origin origin, std::vector<shared_value> stack) const {
         return make_shared<config_delayed_merge_object>(move(origin), move(stack));
     }

--- a/lib/src/values/simple_config_object.cc
+++ b/lib/src/values/simple_config_object.cc
@@ -193,6 +193,10 @@ namespace hocon {
         return resolve_result<shared_value>(modifier.context, value);
     }
 
+    shared_object simple_config_object::new_copy(resolve_status const &new_status, shared_origin new_origin) const {
+        return make_shared<simple_config_object>(move(new_origin), _value, move(new_status), ignores_fallbacks());
+    }
+
     shared_ptr<simple_config_object> simple_config_object::modify(no_exceptions_modifier& modifier) const
     {
         return modify_may_throw(modifier);


### PR DESCRIPTION
This commit implements the `new_copy` and `attempt_peek_with_partial_resolve`
methods of the config_delayed_merge_object class.
