### PR TITLE
(HC-66) Implement create_value_under_path()

### DIFF
--- a/lib/inc/hocon/config_object.hpp
+++ b/lib/inc/hocon/config_object.hpp
@@ -31,6 +31,20 @@ namespace hocon {
         virtual shared_object with_value(path raw_path, shared_value value) const = 0;
         virtual shared_object with_value(std::string key, shared_value value) const = 0;
 
+        /**
+         * Look up the key on an only-partially-resolved object, with no
+         * transformation or type conversion of any kind; if 'this' is not resolved
+         * then try to look up the key anyway if possible.
+         *
+         * @param key
+         *            key to look up
+         * @return the value of the key, or null if known not to exist
+         * @throws config_exception
+         *             if can't figure out key's value (or existence) without more
+         *             resolving
+         */
+        virtual shared_value attempt_peek_with_partial_resolve(std::string const& key) const = 0;
+
         // map interface
         using iterator = std::unordered_map<std::string, shared_value>::const_iterator;
         virtual bool is_empty() const = 0;
@@ -41,7 +55,6 @@ namespace hocon {
         virtual iterator end() const = 0;
 
     protected:
-        virtual shared_value attempt_peek_with_partial_resolve(std::string const& key) const = 0;
         shared_value peek_path(path desired_path) const;
         shared_value peek_assuming_resolved(std::string const& key, path original_path) const;
 

--- a/lib/inc/internal/config_parser.hpp
+++ b/lib/inc/internal/config_parser.hpp
@@ -32,6 +32,7 @@ namespace hocon { namespace config_parser {
         config_syntax _flavor;
         shared_origin _base_origin, _line_origin;
         std::vector<path> _path_stack;
+
     public:
         parse_context(config_syntax flavor, shared_origin origin, std::shared_ptr<const config_node_root> document,
                 std::shared_ptr<const full_includer> includer, shared_include_context include_context);
@@ -41,6 +42,7 @@ namespace hocon { namespace config_parser {
         int array_count;
 
     private:
+        static shared_object create_value_under_path(path p, shared_value value);
         shared_origin line_origin() const;
         path full_current_path() const;
         shared_value parse_value(shared_node_value n, std::vector<std::string>& comments);

--- a/lib/tests/conf_parser_test.cc
+++ b/lib/tests/conf_parser_test.cc
@@ -596,8 +596,8 @@ TEST_CASE("track comments for multiple fields") {
     assert_comments({" before entire array", " after entire array"}, conf7, "array");
 }
 
+// TODO: this test used to fail due to an unimplemented method. Now it seems to reveal a bug in comment handling.
 TEST_CASE("track comments for multiple fields (pending)", "[!shouldfail]") {
-    // TODO: implement createValueUnderPath
     // properties-like syntax
     auto conf8 = parse_config(R"(
             # ignored comment
@@ -623,6 +623,8 @@ TEST_CASE("track comments for multiple fields (pending)", "[!shouldfail]") {
     assert_comments({" a.d comment"}, conf8, "a.d");
     // here we're concerned that comments apply only to leaf
     // nodes, not to parent objects.
+
+    // TODO: comments are currently being applied to the root as well. Why?
     assert_comments({}, conf8, "x");
     assert_comments({}, conf8, "a");
 }

--- a/lib/tests/test_utils.cc
+++ b/lib/tests/test_utils.cc
@@ -313,10 +313,9 @@ namespace hocon { namespace test_utils {
         parse_test(R"({ "foo" : null bar 42 baz true 3.14 "hi" })"), // bunch of values to concat into a string
         parse_test("{ foo : \"bar\" }"), // no quotes on key
         parse_test("{ foo : bar }"), // no quotes on key or value
-        // TODO: createValueUnderPath unimplemented
-        // parse_test("{ foo.bar : bar }"), // path expression in key
-        // parse_test("{ foo.\"hello world\".baz : bar }"), // partly-quoted path expression in key
-        // parse_test("{ foo.bar \n : bar }"), // newline after path expression in key
+        parse_test("{ foo.bar : bar }"), // path expression in key
+        parse_test("{ foo.\"hello world\".baz : bar }"), // partly-quoted path expression in key
+        parse_test("{ foo.bar \n : bar }"), // newline after path expression in key
         parse_test("{ foo  bar : bar }"), // whitespace in the key
         parse_test("{ true : bar }"), // key is a non-string token
         parse_test(R"({ "foo" : "bar", "foo" : "bar2" })", true), // dup keys - lift just returns both


### PR DESCRIPTION
This implements create_value_under_path() in the config_parser. Tests that previously failed due to this method not existing now either pass or fail due to unrelated bugs (see HC-78).

We should decide on the best format for marking known test failures. I used "(pending <ticket_number>)" where a ticket had been made, and just "(pending)" otherwise. But this is not consistent throughout at the moment.