### PR TITLE
(HC-43) Implement unwrap functions for config values

### DIFF
--- a/lib/inc/hocon/config.hpp
+++ b/lib/inc/hocon/config.hpp
@@ -569,6 +569,7 @@ namespace hocon {
         virtual shared_config get_config(std::string const& path) const;
         virtual std::shared_ptr<const config_value> get_value(std::string const& path) const;
 
+        virtual shared_list get_list(std::string const& path) const;
         virtual std::vector<bool> get_bool_list(std::string const& path) const;
         virtual std::vector<int> get_int_list(std::string const& path) const;
         virtual std::vector<int64_t> get_long_list(std::string const& path) const;

--- a/lib/inc/hocon/config_list.hpp
+++ b/lib/inc/hocon/config_list.hpp
@@ -46,5 +46,6 @@ namespace hocon {
         virtual shared_value get(size_t index) const = 0;
         virtual iterator begin() const = 0;
         virtual iterator end() const = 0;
+        virtual unwrapped_value unwrapped() const = 0;
     };
 }  // namespace hocon

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -91,6 +91,8 @@ namespace hocon {
             return type_name(value_type());
         }
 
+        virtual unwrapped_value unwrapped() const = 0;
+
         /**
          * Renders the config value as a HOCON string. This method is primarily
          * intended for debugging, so it tries to add helpful comments and

--- a/lib/inc/hocon/types.hpp
+++ b/lib/inc/hocon/types.hpp
@@ -2,6 +2,8 @@
 
 #include <memory>
 #include <vector>
+#include <unordered_map>
+#include "boost/variant.hpp"
 
 namespace hocon {
 
@@ -18,6 +20,13 @@ namespace hocon {
 
     class config_value;
     using shared_value = std::shared_ptr<const config_value>;
+
+    class config_list;
+    using shared_list = std::shared_ptr<const config_list>;
+
+    typedef boost::make_recursive_variant<boost::blank, std::string, int64_t, double, int, bool,
+            std::vector<boost::recursive_variant_>, std::unordered_map<std::string,
+                    boost::recursive_variant_>>::type unwrapped_value;
 
     class container;
     using shared_container = std::shared_ptr<const container>;

--- a/lib/inc/internal/values/config_boolean.hpp
+++ b/lib/inc/internal/values/config_boolean.hpp
@@ -11,6 +11,8 @@ namespace hocon {
         config_value::type value_type() const override;
         std::string transform_to_string() const override;
 
+        unwrapped_value unwrapped() const override;
+
         bool bool_value() const;
         bool operator==(config_value const& other) const override;
 

--- a/lib/inc/internal/values/config_concatenation.hpp
+++ b/lib/inc/internal/values/config_concatenation.hpp
@@ -38,6 +38,8 @@ namespace hocon {
         static shared_value concatenate(std::vector<shared_value> pieces);
         shared_value relativized(std::string prefix) const override;
 
+        unwrapped_value unwrapped() const override;
+
         bool operator==(config_value const& other) const override;
 
     protected:

--- a/lib/inc/internal/values/config_delayed_merge.hpp
+++ b/lib/inc/internal/values/config_delayed_merge.hpp
@@ -22,6 +22,8 @@ namespace hocon {
 
         std::vector<shared_value> unmerged_values() const override;
 
+        unwrapped_value unwrapped() const override;
+
         resolve_result<shared_value> resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
         static resolve_result<shared_value> resolve_substitutions(std::shared_ptr<const replaceable_merge_stack> replaceable, const std::vector<shared_value>& _stack, resolve_context const& context, resolve_source const& source);
         resolve_status get_resolve_status() const override { return resolve_status::UNRESOLVED; }

--- a/lib/inc/internal/values/config_delayed_merge_object.hpp
+++ b/lib/inc/internal/values/config_delayed_merge_object.hpp
@@ -24,6 +24,7 @@ namespace hocon {
         shared_value get(std::string const& key) const override { throw not_resolved(); }
         iterator begin() const override { throw not_resolved(); }
         iterator end() const override { throw not_resolved(); }
+        unwrapped_value unwrapped() const override;
 
         bool operator==(config_value const& other) const override;
 

--- a/lib/inc/internal/values/config_double.hpp
+++ b/lib/inc/internal/values/config_double.hpp
@@ -13,6 +13,8 @@ namespace hocon {
 
         std::string transform_to_string() const override;
 
+        unwrapped_value unwrapped() const override;
+
         int64_t long_value() const override;
         double double_value() const override;
 

--- a/lib/inc/internal/values/config_int.hpp
+++ b/lib/inc/internal/values/config_int.hpp
@@ -10,6 +10,8 @@ namespace hocon {
 
         std::string transform_to_string() const override;
 
+        unwrapped_value unwrapped() const override;
+
         int64_t long_value() const override;
         double double_value() const override;
 

--- a/lib/inc/internal/values/config_long.hpp
+++ b/lib/inc/internal/values/config_long.hpp
@@ -13,6 +13,8 @@ namespace hocon {
 
         std::string transform_to_string() const override;
 
+        unwrapped_value unwrapped() const override;
+
         int64_t long_value() const override;
         double double_value() const override;
 

--- a/lib/inc/internal/values/config_null.hpp
+++ b/lib/inc/internal/values/config_null.hpp
@@ -21,6 +21,8 @@ namespace hocon {
         config_value::type value_type() const override;
         std::string transform_to_string() const override;
 
+        unwrapped_value unwrapped() const override;
+
         bool operator==(config_value const& other) const override;
 
     protected:

--- a/lib/inc/internal/values/config_reference.hpp
+++ b/lib/inc/internal/values/config_reference.hpp
@@ -19,6 +19,7 @@ namespace hocon {
         type value_type() const override;
         std::vector<shared_value> unmerged_values() const override;
         resolve_status get_resolve_status() const override;
+        unwrapped_value unwrapped() const override;
 
         std::shared_ptr<substitution_expression> expression() const;
 

--- a/lib/inc/internal/values/config_string.hpp
+++ b/lib/inc/internal/values/config_string.hpp
@@ -13,6 +13,8 @@ namespace hocon {
         config_value::type value_type() const override;
         std::string transform_to_string() const override;
 
+        unwrapped_value unwrapped() const override;
+
         bool was_quoted() const;
         bool operator==(config_value const& other) const override;
 

--- a/lib/inc/internal/values/simple_config_list.hpp
+++ b/lib/inc/internal/values/simple_config_list.hpp
@@ -3,6 +3,7 @@
 #include <hocon/config_value.hpp>
 #include <hocon/config_list.hpp>
 #include <hocon/config_render_options.hpp>
+#include <hocon/config_exception.hpp>
 #include <internal/container.hpp>
 #include <algorithm>
 #include <memory>
@@ -17,7 +18,6 @@ namespace hocon {
         simple_config_list(shared_origin origin, std::vector<shared_value> value, resolve_status status);
 
         config_value::type value_type() const override { return config_value::type::LIST; }
-        // unwrapped()
         resolve_status get_resolve_status() const override { return _resolved; }
 
         shared_value replace_child(shared_value const& child, shared_value replacement) const override;
@@ -46,6 +46,8 @@ namespace hocon {
         iterator end() const override { return _value.end(); }
 
         std::shared_ptr<const simple_config_list> concatenate(std::shared_ptr<const simple_config_list> other) const;
+
+        unwrapped_value unwrapped() const override;
 
         bool operator==(config_value const& other) const override;
 

--- a/lib/inc/internal/values/simple_config_object.hpp
+++ b/lib/inc/internal/values/simple_config_object.hpp
@@ -23,6 +23,7 @@ namespace hocon {
         shared_value get(std::string const& key) const override { return _value.at(key); }
         iterator begin() const override { return _value.begin(); }
         iterator end() const override { return _value.end(); }
+        unwrapped_value unwrapped() const override;
 
         std::unordered_map<std::string, shared_value> const& entry_set() const override;
 

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -1,5 +1,6 @@
 #include <hocon/config.hpp>
 #include <hocon/config_parse_options.hpp>
+#include <hocon/config_list.hpp>
 #include <hocon/config_exception.hpp>
 #include <internal/default_transformer.hpp>
 #include <internal/resolve_context.hpp>
@@ -222,6 +223,9 @@ namespace hocon {
         return get_object(path_expression)->to_config();
     }
 
+    shared_list config::get_list(string const& path_expression) const {
+        return dynamic_pointer_cast<const config_list>(find(path_expression, config_value::type::LIST));
+    }
 
     vector<bool> config::get_bool_list(string const& path) const {
         throw config_exception("get_bool_list unimplemented");

--- a/lib/src/values/config_boolean.cc
+++ b/lib/src/values/config_boolean.cc
@@ -19,6 +19,10 @@ namespace hocon {
         return _value;
     }
 
+    unwrapped_value config_boolean::unwrapped() const {
+        return _value;
+    }
+
     shared_value config_boolean::new_copy(shared_origin origin) const {
         return make_shared<config_boolean>(move(origin), _value);
     }

--- a/lib/src/values/config_concatenation.cc
+++ b/lib/src/values/config_concatenation.cc
@@ -170,6 +170,10 @@ namespace hocon {
         return make_shared<config_concatenation>(move(origin), _pieces);
     }
 
+    unwrapped_value config_concatenation::unwrapped() const {
+        throw config_exception("Not resolved, call config::resolve() before attempting to unwrap. See API docs.");
+    }
+
     bool config_concatenation::ignores_fallbacks() const {
         // we can never ignore fallbacks because if a child ConfigReference
         // is self-referential we have to look lower in the merge stack

--- a/lib/src/values/config_delayed_merge.cc
+++ b/lib/src/values/config_delayed_merge.cc
@@ -49,7 +49,11 @@ namespace hocon {
     }
 
     config_value::type config_delayed_merge::value_type() const {
-        throw config_exception("called value_type() on value with unresolved substitutions, need to config#resolve() first, see API docs");
+        throw config_exception("called value_type() on value with unresolved substitutions, need to config#resolve() first, see API docs.");
+    }
+
+    unwrapped_value config_delayed_merge::unwrapped() const {
+        throw config_exception("called unwrapped() on value with unresolved substitutions, need to config::resolve() first, see API docs.");
     }
 
     vector<shared_value> config_delayed_merge::unmerged_values() const {

--- a/lib/src/values/config_delayed_merge_object.cc
+++ b/lib/src/values/config_delayed_merge_object.cc
@@ -43,6 +43,10 @@ namespace hocon {
         return make_shared<config_delayed_merge_object>(move(origin), _stack);
     }
 
+    unwrapped_value config_delayed_merge_object::unwrapped() const {
+        throw config_exception("need to config::resolve before using this object, see the API docs.");
+    }
+
     shared_value config_delayed_merge_object::attempt_peek_with_partial_resolve(string const& key) const {
         /* a partial resolve of a ConfigDelayedMergeObject always results in a
          * SimpleConfigObject because all the substitutions in the stack get

--- a/lib/src/values/config_double.cc
+++ b/lib/src/values/config_double.cc
@@ -16,6 +16,10 @@ namespace hocon {
         }
     }
 
+    unwrapped_value config_double::unwrapped() const {
+        return _value;
+    }
+
     int64_t config_double::long_value() const {
         return static_cast<int64_t>(_value);
     }

--- a/lib/src/values/config_int.cc
+++ b/lib/src/values/config_int.cc
@@ -16,6 +16,10 @@ namespace hocon {
         }
     }
 
+    unwrapped_value config_int::unwrapped() const {
+        return _value;
+    }
+
     int64_t config_int::long_value() const {
         return _value;
     }

--- a/lib/src/values/config_long.cc
+++ b/lib/src/values/config_long.cc
@@ -16,6 +16,10 @@ namespace hocon {
         }
     }
 
+    unwrapped_value config_long::unwrapped() const {
+        return _value;
+    }
+
     int64_t config_long::long_value() const {
         return _value;
     }

--- a/lib/src/values/config_null.cc
+++ b/lib/src/values/config_null.cc
@@ -1,4 +1,5 @@
 #include <internal/values/config_null.hpp>
+#include <boost/blank.hpp>
 
 using namespace std;
 
@@ -17,6 +18,10 @@ namespace hocon {
 
     shared_value config_null::new_copy(shared_origin origin) const {
         return make_shared<config_null>(move(origin));
+    }
+
+    unwrapped_value config_null::unwrapped() const {
+        return boost::blank();
     }
 
     bool config_null::operator==(config_value const& other) const {

--- a/lib/src/values/config_reference.cc
+++ b/lib/src/values/config_reference.cc
@@ -21,6 +21,10 @@ namespace hocon {
         return {shared_from_this()};
     }
 
+    unwrapped_value config_reference::unwrapped() const {
+        throw not_resolved_exception("Can't unwrap a config reference.");
+    }
+
     shared_value config_reference::new_copy(shared_origin origin) const {
         return make_shared<config_reference>(origin, _expr, _prefix_length);
     }

--- a/lib/src/values/config_string.cc
+++ b/lib/src/values/config_string.cc
@@ -19,6 +19,10 @@ namespace hocon {
         return make_shared<config_string>(move(origin), _text, _quoted);
     }
 
+    unwrapped_value config_string::unwrapped() const {
+        return _text;
+    }
+
     bool config_string::was_quoted() const {
         return _quoted == config_string_type::QUOTED;
     }

--- a/lib/src/values/config_value.cc
+++ b/lib/src/values/config_value.cc
@@ -222,7 +222,8 @@ namespace hocon {
 
         auto unmerged_values = fallback->unmerged_values();
         stack.insert(stack.end(), make_move_iterator(unmerged_values.begin()), make_move_iterator(unmerged_values.end()));
-        return construct_delayed_merge(config_object::merge_origins(stack), move(stack));
+        auto merged = config_object::merge_origins(stack);
+        return construct_delayed_merge(merged, move(stack));
     }
 
     shared_value config_value::merged_with_the_unmergeable(std::shared_ptr<const unmergeable> fallback) const {

--- a/lib/src/values/simple_config_list.cc
+++ b/lib/src/values/simple_config_list.cc
@@ -160,6 +160,15 @@ namespace hocon {
         }
     }
 
+
+    unwrapped_value simple_config_list::unwrapped() const {
+        vector<unwrapped_value> values;
+        for (auto it = _value.begin(), endIt = _value.end(); it != endIt; ++it) {
+            values.emplace_back((*it)->unwrapped());
+        }
+        return values;
+    }
+
     std::shared_ptr<const simple_config_list>
     simple_config_list::modify(no_exceptions_modifier& modifier,
                                boost::optional<resolve_status> new_resolve_status) const
@@ -201,5 +210,6 @@ namespace hocon {
             return dynamic_pointer_cast<const simple_config_list>(shared_from_this());
         }
     }
+
 
 }  // namespace hocon

--- a/lib/src/values/simple_config_object.cc
+++ b/lib/src/values/simple_config_object.cc
@@ -175,6 +175,15 @@ namespace hocon {
         return make_shared<simple_config_object>(move(origin), _value, _resolved, _ignores_fallbacks);
     }
 
+    unwrapped_value simple_config_object::unwrapped() const {
+        unordered_map<string, unwrapped_value> contents;
+        for (auto pair : _value) {
+            unwrapped_value v = pair.second->unwrapped();
+            contents[pair.first] = pair.second->unwrapped();
+        }
+        return contents;
+    }
+
     bool simple_config_object::operator==(config_value const& other) const {
         return equals<simple_config_object>(other, [&](simple_config_object const& o) { return _value == o._value; });
     }

--- a/lib/tests/config_substitution_test.cc
+++ b/lib/tests/config_substitution_test.cc
@@ -480,8 +480,9 @@ z = 15
 
     REQUIRE(dynamic_pointer_cast<const config_delayed_merge_object>(problem->attempt_peek_with_partial_resolve("item1")));
 
-    // TODO: Java uses unwrapped() to pull the value out of this object. Do we have a way to do this?
-    // REQUIRE(101 == problem->to_config()->get_object("item1")->attempt_peek_with_partial_resolve("xyz"));
+    unwrapped_value expected(10);
+    bool test = expected == problem->to_config()->get_object("item1")->attempt_peek_with_partial_resolve("xyz")->unwrapped();
+    REQUIRE(test);
 
     auto resolved = resolve_without_fallbacks(problem);
     REQUIRE(parse_object("{ c : 43 }") == resolved->get_object("item1.b"));

--- a/lib/tests/config_value_test.cc
+++ b/lib/tests/config_value_test.cc
@@ -1,5 +1,8 @@
 #include <catch.hpp>
 
+#include <internal/values/simple_config_object.hpp>
+#include <internal/values/simple_config_list.hpp>
+
 #include "test_utils.hpp"
 
 using namespace hocon;
@@ -82,3 +85,27 @@ TEST_CASE("config numbers ints vs longs vs doubles", "[tokenizer]") {
         REQUIRE_FALSE(dynamic_pointer_cast<config_int>(num));
     }
 }
+
+TEST_CASE("config object unwraps") {
+    auto value1 = config_int::new_number(fake_origin(), int64_t(1), "1");
+    auto value2 = config_int::new_number(fake_origin(), int64_t(2), "2");
+    auto value3 = config_int::new_number(fake_origin(), int64_t(3), "3");
+    unordered_map<string, shared_value> org {{"a", value1}, {"b", value2}, {"c", value3}};
+    auto obj = make_shared<const simple_config_object>(fake_origin(), org);
+    unordered_map<string, unwrapped_value> map {{"a", 1}, {"b", 2}, {"c", 3}};
+    unwrapped_value expected(map);
+    bool test = expected == obj->unwrapped();
+    REQUIRE(test);
+}
+
+TEST_CASE("config list unwraps") {
+    auto value1 = config_int::new_number(fake_origin(), int64_t(1), "1");
+    auto value2 = config_int::new_number(fake_origin(), int64_t(2), "2");
+    auto value3 = config_int::new_number(fake_origin(), int64_t(3), "3");
+    vector<shared_value> data { value1, value2, value3 };
+    auto list = make_shared<const simple_config_list>(fake_origin(), data);
+    vector<unwrapped_value> v { 1,2,3 };
+    unwrapped_value expected(v);
+    bool test = expected == list->unwrapped();
+    REQUIRE(test);
+};


### PR DESCRIPTION
This implements unwrapped() methods for all the various config values. For some, this involves recursive unwrapping of objects and lists, and some others throw "not resolved" exceptions.

Having this method allowed me to implement some additional tests that were blocked simply by unwrapped(). However, some nearby tests rely on the specifically-typed config::get_*_list methods. Do we consider implementing those part of this ticket, or should we leave it for another time?