### PR TITLE
(HC-36) Implement ConfigValueFactory API and tests

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -68,7 +68,7 @@ set(PROJECT_SOURCES
     src/resolve_context.cc
     src/resolve_source.cc
     src/values/config_concatenation.cc
-    )
+    src/config_value_factory.cc)
 
 
 ## An object target is generated that can be used by both the library and test executable targets.

--- a/lib/inc/hocon/config.hpp
+++ b/lib/inc/hocon/config.hpp
@@ -567,6 +567,7 @@ namespace hocon {
         virtual std::string get_string(std::string const& path) const;
         virtual std::shared_ptr<const config_object> get_object(std::string const& path) const;
         virtual shared_config get_config(std::string const& path) const;
+        virtual unwrapped_value get_any_ref(std::string const& path) const;
         virtual std::shared_ptr<const config_value> get_value(std::string const& path) const;
 
         virtual shared_list get_list(std::string const& path) const;

--- a/lib/inc/hocon/config_value_factory.hpp
+++ b/lib/inc/hocon/config_value_factory.hpp
@@ -1,0 +1,47 @@
+# pragma once
+
+#include "types.hpp"
+#include "export.h"
+
+namespace hocon {
+    class LIBCPP_HOCON_EXPORT config_value_factory {
+         public:
+         /**
+          * Creates a {@link ConfigValue} from a plain value, which may be
+          * a <code>bool</code>, <code>long</code>, <code>string</code>,
+          * <code>unordered_map</code>, <code>vector</code> or <code>nullptr</code>. An
+          * <code>unordered_map</code> must be a <code>unordered_map</code> from string to more values
+          * that can be supplied to <code>from_any_ref()</code>. An <code>unordered_map</code>
+          * will become a {@link ConfigObject} and a <code>vector</code> will become a
+          * {@link ConfigList}.
+          *
+          * <p>
+          * In a <code>unordered_map</code> passed to <code>from_any_ref()</code>, the map's keys
+          * are plain keys, not path expressions. So if your <code>unordered_map</code> has a
+          * key "foo.bar" then you will get one object with a key called "foo.bar",
+          * rather than an object with a key "foo" containing another object with a
+          * key "bar".
+          *
+          * <p>
+          * The origin_description will be used to set the origin() field on the
+          * ConfigValue. It should normally be the name of the file the values came
+          * from, or something short describing the value such as "default settings".
+          * The origin_description is prefixed to error messages so users can tell
+          * where problematic values are coming from.
+          *
+          * <p>
+          * Supplying the result of ConfigValue.unwrapped() to this function is
+          * guaranteed to work and should give you back a ConfigValue that matches
+          * the one you unwrapped. The re-wrapped ConfigValue will lose some
+          * information that was present in the original such as its origin, but it
+          * will have matching values.
+          *
+          * @param unwrapped_value object
+          *         object to convert to ConfigValue
+          * @param string origin_description
+          *         name of origin file or brief description of what the value is
+          * @return shared_value a new value
+          * */
+       static shared_value from_any_ref(unwrapped_value value, std::string origin_description = "");
+    };
+}  // namespace hocon

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -219,6 +219,10 @@ namespace hocon {
         return dynamic_pointer_cast<const config_object>(find(path_expression, config_value::type::OBJECT));
     }
 
+    unwrapped_value config::get_any_ref(string const& path_expression) const {
+        return find(path_expression, config_value::type::UNSPECIFIED)->unwrapped();
+    }
+
     shared_config config::get_config(string const& path_expression) const {
         return get_object(path_expression)->to_config();
     }

--- a/lib/src/config_value_factory.cc
+++ b/lib/src/config_value_factory.cc
@@ -1,0 +1,68 @@
+#include <hocon/config_value_factory.hpp>
+#include <internal/values/config_null.hpp>
+#include <internal/values/config_string.hpp>
+#include <internal/values/config_long.hpp>
+#include <internal/values/config_double.hpp>
+#include <internal/values/config_int.hpp>
+#include <internal/values/config_boolean.hpp>
+#include <internal/values/simple_config_list.hpp>
+#include <internal/values/simple_config_object.hpp>
+
+namespace hocon {
+
+    using namespace std;
+
+    class config_value_visitor : public boost::static_visitor<shared_value> {
+    public:
+        // TODO: If use cases of from_any_ref require other types to produce config_nulls,
+        // we can revise this behavior
+        shared_value operator()(boost::blank null_value) const {
+            return make_shared<const config_null>(nullptr);
+        }
+
+        shared_value operator()(string str) const {
+            return make_shared<const config_string>(nullptr, str, config_string_type::QUOTED);
+        }
+
+        shared_value operator()(int64_t num) const {
+            return make_shared<const config_long>(nullptr, num, "");
+        }
+
+        shared_value operator()(double num) const {
+            return make_shared<const config_double>(nullptr, num, "");
+        }
+
+        shared_value operator()(int num) const {
+            return make_shared<const config_int>(nullptr, num, "");
+        }
+
+        shared_value operator()(bool boolean) const {
+            return make_shared<const config_boolean>(nullptr, boolean);
+        }
+
+        shared_value operator()(vector<unwrapped_value> value_list) const {
+            vector<shared_value> config_values;
+            for (unwrapped_value v : value_list) {
+                config_values.emplace_back(boost::apply_visitor(config_value_visitor(), v));
+            }
+            return make_shared<const simple_config_list>(nullptr, config_values);
+        }
+
+        shared_value operator()(unordered_map<string, unwrapped_value> value_map) const {
+            unordered_map<string, shared_value> config_map;
+            for (auto pair : value_map) {
+                config_map[pair.first] = boost::apply_visitor(config_value_visitor(), pair.second);
+            }
+            return make_shared<const simple_config_object>(nullptr, config_map);
+        }
+    };
+
+    shared_value config_value_factory::from_any_ref(unwrapped_value value, std::string origin) {
+        // If no origin is specified, create a default one.
+        if (origin.empty()) {
+            origin = "hardcoded value";
+        }
+        auto conf_origin = make_shared<const simple_config_origin>(origin);
+        return boost::apply_visitor(config_value_visitor(), value)->with_origin(conf_origin);
+    }
+}  // namespace hocon

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -12,7 +12,8 @@ set(TEST_CASES
     test_utils.cc
     config_document_tests.cc
     conf_parser_test.cc
-    config_substitution_test.cc)
+    config_substitution_test.cc
+    config_value_factory_test.cc)
 
 add_executable(lib${PROJECT_NAME}_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
 target_link_libraries(lib${PROJECT_NAME}_test

--- a/lib/tests/config_value_factory_test.cc
+++ b/lib/tests/config_value_factory_test.cc
@@ -1,0 +1,60 @@
+#include <catch.hpp>
+#include "test_utils.hpp"
+
+#include <hocon/config_value_factory.hpp>
+#include <internal/values/simple_config_object.hpp>
+
+using namespace hocon;
+using namespace std;
+
+TEST_CASE("convert various types to config values", "[config_value_factory]") {
+    SECTION("true should convert to config_boolean") {
+        auto value = config_value_factory::from_any_ref(true, "");
+        REQUIRE(dynamic_pointer_cast<const config_boolean>(value));
+        REQUIRE(boost::get<bool>(value->unwrapped()) == true);
+    }
+
+    SECTION("false should convert to config_boolean") {
+        auto value = config_value_factory::from_any_ref(false, "");
+        REQUIRE(dynamic_pointer_cast<const config_boolean>(value));
+        REQUIRE(boost::get<bool>(value->unwrapped()) == false);
+    }
+
+    SECTION("a null value should convert to config_null") {
+        auto value = config_value_factory::from_any_ref(boost::blank(), "");
+        REQUIRE(dynamic_pointer_cast<const config_null>(value));
+        REQUIRE(boost::get<boost::blank>(value->unwrapped()) == boost::blank());
+    }
+
+    SECTION("string should convert to config_string") {
+        auto value = config_value_factory::from_any_ref(string("test"), "");
+        REQUIRE(dynamic_pointer_cast<const config_string>(value));
+        REQUIRE(boost::get<string>(value->unwrapped()) == "test");
+    }
+
+    SECTION("int should convert to config_int") {
+        auto value = config_value_factory::from_any_ref(2, "");
+        REQUIRE(dynamic_pointer_cast<const config_int>(value));
+        REQUIRE(boost::get<int>(value->unwrapped()) == 2);
+    }
+
+    SECTION("double should covert to config_double") {
+        auto value = config_value_factory::from_any_ref(4.5, "");
+        REQUIRE(dynamic_pointer_cast<const config_double>(value));
+        REQUIRE(boost::get<double>(value->unwrapped()) == 4.5);
+    }
+
+    SECTION("long (int64_t) should convert to config_long") {
+        auto value = config_value_factory::from_any_ref(int64_t(19), "");
+        REQUIRE(dynamic_pointer_cast<const config_long>(value));
+        REQUIRE(boost::get<int64_t>(value->unwrapped()) == 19);
+    }
+
+    SECTION("map should convert to simple_config_object") {
+        unordered_map<string, unwrapped_value> map {{ "a", 1 }, { "b", "string" }, { "c", false }};
+        auto value = config_value_factory::from_any_ref(map, "");
+        REQUIRE(dynamic_pointer_cast<const simple_config_object>(value));
+        auto unwrapped = boost::get<unordered_map<string, unwrapped_value>>(value->unwrapped());
+        REQUIRE(unwrapped == map);
+    }
+}


### PR DESCRIPTION
This class is used to turn C++ types into config_values. The types it
can accept are limited by the bounded types of the boost::variant used
when unwrapping config_values.