### PR TITLE
(FACT-1456) Add utility to wrap hocon in boost::program_options

### DIFF
--- a/lib/inc/hocon/program_options.hpp
+++ b/lib/inc/hocon/program_options.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "config.hpp"
+#include "config_list.hpp"
+
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+
+namespace hocon { namespace program_options {
+    namespace po = boost::program_options;
+
+    template<class charT>
+    po::basic_parsed_options<charT>
+    parse_hocon(shared_config cfg, const po::options_description& desc, bool allow_unregistered) {
+        po::parsed_options result(&desc);
+
+        std::map<std::string, shared_config> to_do;
+        to_do.emplace("", cfg);
+
+        while (!to_do.empty()) {
+            auto iter = to_do.begin();
+            auto prefix = iter->first;
+            auto cfg = iter->second;
+            to_do.erase(iter);
+
+            for (const auto& entry : cfg->entry_set()) {
+                po::option opt;
+
+                // TODO: enforce unregistered variable flag based on allow_unregistered setting
+
+                if (prefix.empty()) {
+                    opt.string_key = entry.first;
+                } else {
+                    opt.string_key = prefix + "." + entry.first;
+                }
+
+                if (entry.second->value_type() == config_value::type::LIST) {
+                    // if this is a list, we want to check if any of the entries are
+                    // objects. If so, we need to further expand those sub-trees, with
+                    // list indices being expanded into our key
+
+                    auto list = std::dynamic_pointer_cast<const config_list>(entry.second);
+                    for (size_t i = 0; i < list->size(); ++i) {
+                        const auto& value = list->get(i);
+                        if (value->value_type() == config_value::type::LIST ||
+                            value->value_type() == config_value::type::OBJECT) {
+                            boost::throw_exception(po::invalid_config_file_syntax(list->transform_to_string(), po::invalid_syntax::unrecognized_line));
+                        } else {
+                            opt.value.push_back(value->transform_to_string());
+                        }
+                    }
+                } else {
+                    opt.value.push_back(entry.second->transform_to_string());
+                }
+                if (!opt.value.empty()) {
+                    result.options.emplace_back(std::move(opt));
+                }
+            }
+        }
+
+        // let Boost convert our utf-8 entries to wchars if needed
+        return po::basic_parsed_options<charT>(result);
+    }
+
+    template<class charT>
+    po::basic_parsed_options<charT>
+    parse_file(std::basic_string<charT> file_basename, const po::options_description& desc, bool allow_unregistered=false) {
+        shared_config cfg = config::parse_file_any_syntax(file_basename)->resolve();
+        return parse_hocon<charT>(cfg, desc, allow_unregistered);
+    }
+
+    template<class charT>
+    po::basic_parsed_options<charT>
+    parse_string(std::basic_string<charT> s, const po::options_description& desc, bool allow_unregistered=false) {
+        shared_config cfg = config::parse_string(s)->resolve();
+        return parse_hocon<charT>(cfg, desc, allow_unregistered);
+    }
+}}

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -14,7 +14,9 @@ set(TEST_CASES
     conf_parser_test.cc
     config_substitution_test.cc
     config_value_factory_test.cc
-    config_test.cc)
+    config_test.cc
+    program_options.cc
+)
 
 add_executable(lib${PROJECT_NAME}_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
 target_link_libraries(lib${PROJECT_NAME}_test

--- a/lib/tests/program_options.cc
+++ b/lib/tests/program_options.cc
@@ -1,0 +1,47 @@
+#include <catch.hpp>
+#include "test_utils.hpp"
+
+#include <hocon/program_options.hpp>
+
+using namespace std;
+using namespace hocon;
+using namespace hocon::program_options;
+
+TEST_CASE("converts hocon obj to boost::po") {
+    po::options_description opts("");
+    opts.add_options()("foo", "description");
+    po::variables_map vm;
+    po::store(parse_string(string("{foo:b}"), opts), vm);
+    REQUIRE(vm.count("foo") == 1);
+}
+
+TEST_CASE("converts structured hocon to boost::po") {
+    po::options_description opts("");
+    opts.add_options()("foo.bar", "description");
+    po::variables_map vm;
+    po::store(parse_string(string("{foo : { bar : baz }}"), opts), vm);
+    REQUIRE(vm.count("foo.bar") == 1);
+}
+
+TEST_CASE("arrays with only values are converted to boost::po") {
+    po::options_description opts("");
+    opts.add_options()("foo", po::value<vector<string>>(), "description");
+    po::variables_map vm;
+    po::store(parse_string(string("{foo : [ bar, baz ]}"), opts), vm);
+    REQUIRE(vm.count("foo") == 1);
+}
+
+TEST_CASE("arrays with objects are converted to paths in boost::po") {
+    po::options_description opts("");
+    opts.add_options()("foo", "description");
+    po::variables_map vm;
+    REQUIRE_THROWS(po::store(parse_string(string("{foo : [ { bar : baz } ]}"), opts), vm));
+}
+
+TEST_CASE("Arrays mixed with objects produce both a field and a nested path in boost:po") {
+    po::options_description opts("");
+    opts.add_options()
+         ("foo", po::value<vector<string>>(), "description");
+    po::variables_map vm;
+    REQUIRE_THROWS(po::store(parse_string(string("{foo : [ quux, {bar : baz } ] }"), opts), vm));
+}


### PR DESCRIPTION
This adds a `hocon::program_options` namespace with a `parse_hocon`
function. This function can be used the same as any of the normal
`program_options` parsers to generate config values, except it takes
as its input a hocon `shared_config` object.

HOCON allows representing certain data structures that
`boost::program_options` can not - specifically hashes inside arrays
cause trouble. We try to reprsent these when possible, (using a syntax
that treats the array index as a "key"), but defining actual
`po::options_description` sets that can represent these is Hard (if
not impossible).