### PR TITLE
(HC-75) Implement config::get_*_list methods.

### DIFF
--- a/lib/inc/hocon/config.hpp
+++ b/lib/inc/hocon/config.hpp
@@ -6,6 +6,7 @@
 #include "config_object.hpp"
 #include "config_resolve_options.hpp"
 #include "config_value.hpp"
+#include "config_list.hpp"
 #include "config_exception.hpp"
 #include "path.hpp"
 #include <vector>
@@ -570,6 +571,20 @@ namespace hocon {
         virtual unwrapped_value get_any_ref(std::string const& path) const;
         virtual std::shared_ptr<const config_value> get_value(std::string const& path) const;
 
+        template<typename T>
+        std::vector<T> get_homogeneous_unwrapped_list(std::string const& path) const {
+            auto list = boost::get<std::vector<unwrapped_value>>(get_list(path)->unwrapped());
+            std::vector<T> T_list;
+            for (auto item : list) {
+                try {
+                    T_list.push_back(boost::get<T>(item));
+                } catch (boost::bad_get &ex) {
+                    throw config_exception("The list did not contain only the desired type.");
+                }
+            }
+            return T_list;
+        }
+
         virtual shared_list get_list(std::string const& path) const;
         virtual std::vector<bool> get_bool_list(std::string const& path) const;
         virtual std::vector<int> get_int_list(std::string const& path) const;
@@ -578,7 +593,6 @@ namespace hocon {
         virtual std::vector<std::string> get_string_list(std::string const& path) const;
         virtual std::vector<shared_object> get_object_list(std::string const& path) const;
         virtual std::vector<shared_config> get_config_list(std::string const& path) const;
-
 
         // TODO: memory and duration parsing
 
@@ -682,10 +696,10 @@ namespace hocon {
         shared_value find_or_null(std::string const& path_expression, config_value::type expected) const;
         shared_value find_or_null(path path_expression, config_value::type expected, path original_path) const;
 
-        template<typename T>
-        std::vector<T> get_homogeneous_unwrapped_list(std::string const& path, config_value::type expected) const;
-
         shared_object _object;
     };
+
+    template<>
+    std::vector<int64_t> config::get_homogeneous_unwrapped_list(std::string const& path) const;
 
 }  // namespace hocon

--- a/lib/inc/internal/values/simple_config_object.hpp
+++ b/lib/inc/internal/values/simple_config_object.hpp
@@ -21,10 +21,16 @@ namespace hocon {
         bool is_empty() const override { return _value.empty(); }
         size_t size() const override { return _value.size(); }
         shared_value operator[](std::string const& key) const override { return _value.at(key); }
-        shared_value get(std::string const& key) const override { return _value.at(key); }
         iterator begin() const override { return _value.begin(); }
         iterator end() const override { return _value.end(); }
         unwrapped_value unwrapped() const override;
+
+        shared_value get(std::string const& key) const override {
+            if (_value.find(key) == _value.end()) {
+                return nullptr;
+            }
+            return _value.at(key);
+        }
 
         std::unordered_map<std::string, shared_value> const& entry_set() const override;
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -13,7 +13,8 @@ set(TEST_CASES
     config_document_tests.cc
     conf_parser_test.cc
     config_substitution_test.cc
-    config_value_factory_test.cc)
+    config_value_factory_test.cc
+    config_test.cc)
 
 add_executable(lib${PROJECT_NAME}_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
 target_link_libraries(lib${PROJECT_NAME}_test

--- a/lib/tests/config_test.cc
+++ b/lib/tests/config_test.cc
@@ -1,0 +1,50 @@
+#include <catch.hpp>
+
+#include <hocon/config.hpp>
+#include "fixtures.hpp"
+
+using namespace std;
+using namespace hocon;
+
+TEST_CASE("should be able to get bare C++ types from a config", "[config]") {
+
+    SECTION("get single values") {
+        auto conf = config::parse_file_any_syntax(TEST_FILE_DIR + string("/fixtures/test01.conf"))->resolve();
+
+        REQUIRE(42 == conf->get_int("ints.fortyTwo"));
+        REQUIRE(42 == conf->get_long("ints.fortyTwoAgain"));
+        REQUIRE(42.1 == conf->get_double("floats.fortyTwoPointOne"));
+        REQUIRE(0.33 == conf->get_double("floats.pointThirtyThree"));
+        REQUIRE("abcd" == conf->get_string("strings.abcd"));
+        REQUIRE("null bar 42 baz true 3.14 hi" == conf->get_string("strings.concatenated"));
+        REQUIRE(true == conf->get_bool("booleans.trueAgain"));
+        REQUIRE(false == conf->get_bool("booleans.falseAgain"));
+
+        REQUIRE(nullptr == conf->root()->get("not_a_setting"));
+    }
+
+    SECTION("get list values") {
+        auto conf = config::parse_file_any_syntax(TEST_FILE_DIR + string("/fixtures/test01.conf"))->resolve();
+
+        vector<int> ints { 1,2,3 };
+        REQUIRE(ints == conf->get_int_list("arrays.ofInt"));
+
+        vector<int64_t> longs { 1, 2, 3 };
+        REQUIRE(longs == conf->get_long_list("arrays.ofInt"));
+
+        vector<string> strings { "a", "b", "c" };
+        REQUIRE(strings == conf->get_string_list("arrays.ofString"));
+
+        vector<double> doubles { 3.14, 4.14, 5.14 };
+        REQUIRE(doubles == conf->get_double_list("arrays.ofDouble"));
+
+        vector<bool> bools { true, false };
+        REQUIRE(bools == conf->get_bool_list("arrays.ofBoolean"));
+
+        REQUIRE(3 == conf->get_object_list("arrays.ofObject").size());
+
+        auto bad_list = "bad : [ 1, \"a string\", 4.5 ]";
+        auto string_conf = config::parse_string(bad_list);
+        REQUIRE_THROWS(string_conf->get_int_list("bad"));
+    };
+}


### PR DESCRIPTION
This commit implements the various get_list methods for supported types,
using a templated backing function which will throw exceptions if the
list is not homogeneous and of the desired type.