### PR TITLE
(HC-62) Implement duration parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.2.2)
 # Project Setup - modify to match project naming
 ## Source code for a simple command-line executable for a dynamic library will be generated from the project name.
 ## The command-line and library names will be based off the project name.
-project(cpp-hocon VERSION 0.1.0)
+project(cpp-hocon VERSION 0.1.2)
 
 string(MAKE_C_IDENTIFIER ${PROJECT_NAME} PROJECT_C_NAME)
 string(TOUPPER ${PROJECT_C_NAME} PROJECT_NAME_UPPER)

--- a/lib/inc/hocon/types.hpp
+++ b/lib/inc/hocon/types.hpp
@@ -7,6 +7,13 @@
 
 namespace hocon {
 
+    /**
+     * A duration represented as a 64-bit integer of seconds plus
+     * a 32-bit number of nanoseconds representing a fraction of a
+     * second.
+     */
+    using duration = std::pair<int64_t, int>;
+
     class config;
     using shared_config = std::shared_ptr<const config>;
 

--- a/lib/tests/config_test.cc
+++ b/lib/tests/config_test.cc
@@ -6,6 +6,7 @@
 
 using namespace std;
 using namespace hocon;
+using namespace hocon::test_utils;
 
 TEST_CASE("should be able to get bare C++ types from a config", "[config]") {
 
@@ -111,5 +112,51 @@ TEST_CASE("correct exceptions should be thrown", "[config]") {
             REQUIRE_STRING_CONTAINS(e.what(), "c has not been resolved");
         }
         REQUIRE(thrown);
+    }
+}
+
+TEST_CASE("should correctly parse durations", "[config]") {
+    auto conf = config::parse_file_any_syntax(TEST_FILE_DIR + string("/fixtures/test01.conf"))->resolve();
+
+    SECTION("should be able to fetch number nodes as durations", "[config]") {
+        REQUIRE(1 == conf->get_duration_as_long("durations.secondAsNumber", time_unit::SECONDS));
+        REQUIRE(1000000000.0 == conf->get_duration_as_double("durations.secondAsNumber", time_unit::NANOSECONDS));
+    }
+
+    SECTION("should be able to get durations in specific units", "[config]") {
+        // Get as a long
+        REQUIRE(1 == conf->get_duration_as_long("durations.second", time_unit::SECONDS));
+        REQUIRE(500 == conf->get_duration_as_long("durations.halfSecond", time_unit::MILLISECONDS));
+        REQUIRE(1 == conf->get_duration_as_long("durations.millis", time_unit::MILLISECONDS));
+        REQUIRE(1000 == conf->get_duration_as_long("durations.second", time_unit::MILLISECONDS));
+        REQUIRE(60 == conf->get_duration_as_long("durations.minute", time_unit::SECONDS));
+        REQUIRE(60 == conf->get_duration_as_long("durations.hour", time_unit::MINUTES));
+        REQUIRE(24 == conf->get_duration_as_long("durations.day", time_unit::HOURS));
+        REQUIRE(-4 == conf->get_duration_as_long("durations.minusSeconds", time_unit::SECONDS));
+        REQUIRE(43 == conf->get_duration_as_long("durations.secondWithFractional", time_unit::SECONDS));
+        REQUIRE(43200 == conf->get_duration_as_long("durations.secondWithFractional", time_unit::MILLISECONDS));
+        REQUIRE(9223372036854775807 == conf->get_duration_as_long("durations.largeNanos", time_unit::NANOSECONDS));
+        REQUIRE(-9223372036854775807 == conf->get_duration_as_long("durations.minusLargeNanos", time_unit::NANOSECONDS));
+        // getting as a long truncates when casting to a larger value
+        REQUIRE(0 == conf->get_duration_as_long("durations.minute", time_unit::HOURS));
+        REQUIRE(9223372036 == conf->get_duration_as_long("durations.largeNanos", time_unit::SECONDS));
+        REQUIRE(153722867 == conf->get_duration_as_long("durations.largeNanos", time_unit::MINUTES));
+        REQUIRE(2562047 == conf->get_duration_as_long("durations.largeNanos", time_unit::HOURS));
+        REQUIRE(106751 == conf->get_duration_as_long("durations.largeNanos", time_unit::DAYS));
+
+        // Get as a double
+        REQUIRE(43.2 == conf->get_duration_as_double("durations.secondWithFractional", time_unit::SECONDS));
+        REQUIRE(43200.0 == conf->get_duration_as_double("durations.secondWithFractional", time_unit::MILLISECONDS));
+        REQUIRE(-4.0 == conf->get_duration_as_double("durations.minusSeconds", time_unit::SECONDS));
+        REQUIRE(0.5 == conf->get_duration_as_double("durations.halfSecond", time_unit::SECONDS));
+        REQUIRE(1000.0 == conf->get_duration_as_double("durations.second", time_unit::MILLISECONDS));
+        // getting as a double retains fractional part
+        REQUIRE((1.0 / 60.0) == conf->get_duration_as_double("durations.minute", time_unit::HOURS));
+    }
+
+    SECTION("should throw an exception when overflow occurs", "[config]") {
+        REQUIRE_THROWS(conf->get_duration_as_long("durations.largeDays", time_unit::DAYS));
+        REQUIRE_THROWS(conf->get_duration_as_double("durations.largeDays", time_unit::NANOSECONDS));
+        REQUIRE_THROWS(conf->get_duration_as_long("durations.largeDays", time_unit::NANOSECONDS));
     }
 }

--- a/lib/tests/fixtures/test01.conf
+++ b/lib/tests/fixtures/test01.conf
@@ -55,14 +55,19 @@
 
     "durations" : {
         "second" : 1s,
+        "minute" : 1 minute,
+        "hour" : 1hour,
+        "day" : 1 day,
+        "secondWithFractional" : 43.2s
         "secondsList" : [1s,2seconds,3 s, 4000],
         "secondAsNumber" : 1000,
         "halfSecond" : 0.5s,
         "millis" : 1 milli,
         "micros" : 2000 micros,
-        "largeNanos" : 4878955355435272204ns,
-        "plusLargeNanos" : "+4878955355435272204ns",
-        "minusLargeNanos" : -4878955355435272204ns
+        "minusSeconds" : -4seconds,
+        "largeNanos" : 9223372036854775807ns,
+        "minusLargeNanos" : -9223372036854775807ns,
+        "largeDays" : 9223372036854775807 days
     },
 
     "memsizes" : {


### PR DESCRIPTION
This implements parsing durations with the aid of boost::chrono::durations. There is a lot of converting back and forth between them, but this seemed the easiest way to handle the type system, short of writing my own custom type.