### PR TITLE
(maint) Fix i18n support and header file declarations

### DIFF
--- a/lib/inc/hocon/config.hpp
+++ b/lib/inc/hocon/config.hpp
@@ -15,9 +15,6 @@
 #include "export.h"
 #include <leatherman/locale/locale.hpp>
 
-// Mark string for translation (alias for leatherman::locale::format)
-using leatherman::locale::_;
-
 namespace hocon {
 
     /**
@@ -583,7 +580,7 @@ namespace hocon {
                 try {
                     T_list.push_back(boost::get<T>(item));
                 } catch (boost::bad_get &ex) {
-                    throw config_exception(_("The list did not contain only the desired type."));
+                    throw config_exception(leatherman::locale::format("The list did not contain only the desired type."));
                 }
             }
             return T_list;

--- a/lib/inc/hocon/config_exception.hpp
+++ b/lib/inc/hocon/config_exception.hpp
@@ -5,9 +5,6 @@
 #include "config_origin.hpp"
 #include <leatherman/locale/locale.hpp>
 
-// Mark string for translation (alias for leatherman::locale::format)
-using leatherman::locale::_;
-
 namespace hocon {
 
     /**
@@ -16,10 +13,10 @@ namespace hocon {
      */
     struct config_exception : public std::runtime_error {
         config_exception(config_origin const& origin, std::string const& message) :
-                runtime_error(_("{1}: {2}", origin.description(), message)) { }
+                runtime_error(leatherman::locale::format("{1}: {2}", origin.description(), message)) { }
         config_exception(std::string const& message) : runtime_error(message) { }
 
-        config_exception(std::string const& message, std::exception const& e) : runtime_error(_("{1} {2}", message, e.what())) { }
+        config_exception(std::string const& message, std::exception const& e) : runtime_error(leatherman::locale::format("{1} {2}", message, e.what())) { }
     };
 
     /**
@@ -30,7 +27,7 @@ namespace hocon {
     struct wrong_type_exception : public config_exception {
         wrong_type_exception(config_origin const& origin,
                              std::string const& path, std::string const& expected, std::string const& actual) :
-                config_exception(origin, _("{1} has type {2} rather than {3}", path, actual, expected)) { }
+                config_exception(origin, leatherman::locale::format("{1} has type {2} rather than {3}", path, actual, expected)) { }
         using config_exception::config_exception;
     };
 
@@ -40,7 +37,7 @@ namespace hocon {
      */
     struct missing_exception : public config_exception {
         missing_exception(std::string const& path) :
-                config_exception(_("No configuration setting found for key '{1}'", path)) { }
+                config_exception(leatherman::locale::format("No configuration setting found for key '{1}'", path)) { }
         using config_exception::config_exception;
     };
 
@@ -50,8 +47,8 @@ namespace hocon {
      */
     struct null_exception : public missing_exception {
         null_exception(config_origin const& origin, std::string const& path, std::string const& expected = "") :
-                missing_exception(origin, (expected.empty() ? _("Configuration key \"{1}\" is null", path)
-                                           : _("Configuration key \"{1}\" is set to null but expected {2}", path, expected))) { }
+                missing_exception(origin, (expected.empty() ? leatherman::locale::format("Configuration key \"{1}\" is null", path)
+                                           : leatherman::locale::format("Configuration key \"{1}\" is set to null but expected {2}", path, expected))) { }
     };
 
     /**
@@ -61,9 +58,9 @@ namespace hocon {
      */
     struct bad_value_exception : public config_exception {
         bad_value_exception(config_origin const& origin, std::string const& path, std::string const& message) :
-                config_exception(origin, _("Invalid value at '{1}': {2}", path, message)) { }
+                config_exception(origin, leatherman::locale::format("Invalid value at '{1}': {2}", path, message)) { }
         bad_value_exception(std::string const& path, std::string const& message) :
-                config_exception(_("Invalid value at '{1}': {2}", path, message)) { }
+                config_exception(leatherman::locale::format("Invalid value at '{1}': {2}", path, message)) { }
     };
 
     /**
@@ -73,9 +70,9 @@ namespace hocon {
      */
     struct bad_path_exception : public config_exception {
         bad_path_exception(config_origin const& origin, std::string const& path, std::string const& message) :
-                config_exception(origin, path.empty() ? message : _("Invalid path '{1}': {2}", path, message)) { }
+                config_exception(origin, path.empty() ? message : leatherman::locale::format("Invalid path '{1}': {2}", path, message)) { }
         bad_path_exception(std::string const& path, std::string const& message) :
-                config_exception(path.empty() ? message : _("Invalid path '{1}': {2}", path, message)) { }
+                config_exception(path.empty() ? message : leatherman::locale::format("Invalid path '{1}': {2}", path, message)) { }
     };
 
     /**
@@ -112,7 +109,7 @@ namespace hocon {
      */
     struct unresolved_substitution_exception : public parse_exception {
         unresolved_substitution_exception(config_origin const& origin, std::string const& detail) :
-                parse_exception(origin, _("Could not resolve subtitution to a value: {1}", detail)) { }
+                parse_exception(origin, leatherman::locale::format("Could not resolve subtitution to a value: {1}", detail)) { }
     };
 
     /**
@@ -145,7 +142,7 @@ namespace hocon {
         const std::string problem;
 
         std::string to_string() {
-            return _("ValidationProblem({1},{2},{3})", path, origin->description(), problem);
+            return leatherman::locale::format("ValidationProblem({1},{2},{3})", path, origin->description(), problem);
         }
     };
 
@@ -171,7 +168,7 @@ namespace hocon {
                 }
             }
             if (msg.empty()) {
-                throw bug_or_broken_exception(_("validation_failed_exception must have a non-empty list of problems"));
+                throw bug_or_broken_exception(leatherman::locale::format("validation_failed_exception must have a non-empty list of problems"));
             }
             msg.resize(msg.length() - 2);
             return msg;

--- a/lib/inc/hocon/config_value.hpp
+++ b/lib/inc/hocon/config_value.hpp
@@ -10,9 +10,6 @@
 #include "export.h"
 #include <leatherman/locale/locale.hpp>
 
-// Mark string for translation (alias for leatherman::locale::format)
-using leatherman::locale::_;
-
 namespace hocon {
 
     class unmergeable;
@@ -68,7 +65,7 @@ namespace hocon {
                 case type::CONFIG_NULL: return "null";
                 case type::STRING: return "string";
                 case type::UNSPECIFIED: return "unspecified";
-                default: throw std::logic_error(_("Got impossible value for type enum"));
+                default: throw std::logic_error(leatherman::locale::format("Got impossible value for type enum"));
             }
         }
 


### PR DESCRIPTION
This fix replaces "using leatherman::locale::_" references in cpp-hocon
header files. Placed in headers, these declarations pollute the namespace
of components, like facter, that include these headers.