### PR TITLE
(maint) Remove the ability to return durations as doubles

### DIFF
--- a/lib/inc/hocon/config.hpp
+++ b/lib/inc/hocon/config.hpp
@@ -600,15 +600,6 @@ namespace hocon {
         // TODO: memory parsing
 
         /**
-         * Gets a value as a decimal number of the specified units.
-         * Correctly handles durations within the range +/-2^63 seconds.
-         * @param path the path to the time value
-         * @param unit the units of the number returned
-         * @return a double representing the value converted to the requested units
-         */
-        virtual double get_duration_as_double(std::string const& path, time_unit unit) const;
-
-        /**
          * Gets a value as an integer number of the specified units.
          * If the result would have a fractional part, the number is truncated.
          * Correctly handles durations within the range +/-2^63 seconds.
@@ -616,7 +607,7 @@ namespace hocon {
          * @param unit the units of the number returned
          * @return a 64-bit integer representing the value converted to the requested units
          */
-        virtual int64_t get_duration_as_long(std::string const& path, time_unit unit) const;
+        virtual int64_t get_duration(std::string const& path, time_unit unit) const;
 
         /**
          * Clone the config with only the given path (and its children) retained;

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -328,41 +328,7 @@ namespace hocon {
         }
     }
 
-    double config::get_duration_as_double(string const& path, time_unit unit) const {
-        auto timespan = get_duration(path);
-        double result = 0.0;
-        switch (unit) {
-            case time_unit::NANOSECONDS:
-                result = (timespan.first * 1000000000.0) + timespan.second;
-                break;
-            case time_unit::MICROSECONDS:
-                result = (timespan.first * 1000000.0) + (timespan.second / 1000.0);
-                break;
-            case time_unit::MILLISECONDS:
-                result = (timespan.first * 1000.0) + (timespan.second / 1000000.0);
-                break;
-            case time_unit::SECONDS:
-                result = timespan.first + (timespan.second / 1000000000.0);
-                break;
-            case time_unit::MINUTES:
-                result = (timespan.first + (timespan.second / 1000000000.0)) / 60.0;
-                break;
-            case time_unit::HOURS:
-                result = (timespan.first + (timespan.second / 1000000000.0)) / 3600.0;
-                break;
-            case time_unit::DAYS:
-                result = (timespan.first + (timespan.second / 1000000000.0)) / 84600.0;
-                break;
-            default:
-                throw config_exception(_("Not a valid time_unit"));
-        }
-        if (!isnormal(result)) {
-            throw config_exception(_("as_double: Overflow occurred during time conversion"));
-        }
-        return result;
-    }
-
-    int64_t config::get_duration_as_long(string const& path, time_unit unit) const {
+    int64_t config::get_duration(string const& path, time_unit unit) const {
         auto timespan = get_duration(path);
         int64_t result = 0;
         switch (unit) {

--- a/lib/tests/config_test.cc
+++ b/lib/tests/config_test.cc
@@ -119,44 +119,33 @@ TEST_CASE("should correctly parse durations", "[config]") {
     auto conf = config::parse_file_any_syntax(TEST_FILE_DIR + string("/fixtures/test01.conf"))->resolve();
 
     SECTION("should be able to fetch number nodes as durations", "[config]") {
-        REQUIRE(1 == conf->get_duration_as_long("durations.secondAsNumber", time_unit::SECONDS));
-        REQUIRE(1000000000.0 == conf->get_duration_as_double("durations.secondAsNumber", time_unit::NANOSECONDS));
+        REQUIRE(1 == conf->get_duration("durations.secondAsNumber", time_unit::SECONDS));
     }
 
     SECTION("should be able to get durations in specific units", "[config]") {
         // Get as a long
-        REQUIRE(1 == conf->get_duration_as_long("durations.second", time_unit::SECONDS));
-        REQUIRE(500 == conf->get_duration_as_long("durations.halfSecond", time_unit::MILLISECONDS));
-        REQUIRE(1 == conf->get_duration_as_long("durations.millis", time_unit::MILLISECONDS));
-        REQUIRE(1000 == conf->get_duration_as_long("durations.second", time_unit::MILLISECONDS));
-        REQUIRE(60 == conf->get_duration_as_long("durations.minute", time_unit::SECONDS));
-        REQUIRE(60 == conf->get_duration_as_long("durations.hour", time_unit::MINUTES));
-        REQUIRE(24 == conf->get_duration_as_long("durations.day", time_unit::HOURS));
-        REQUIRE(-4 == conf->get_duration_as_long("durations.minusSeconds", time_unit::SECONDS));
-        REQUIRE(43 == conf->get_duration_as_long("durations.secondWithFractional", time_unit::SECONDS));
-        REQUIRE(43200 == conf->get_duration_as_long("durations.secondWithFractional", time_unit::MILLISECONDS));
-        REQUIRE(9223372036854775807 == conf->get_duration_as_long("durations.largeNanos", time_unit::NANOSECONDS));
-        REQUIRE(-9223372036854775807 == conf->get_duration_as_long("durations.minusLargeNanos", time_unit::NANOSECONDS));
+        REQUIRE(1 == conf->get_duration("durations.second", time_unit::SECONDS));
+        REQUIRE(500 == conf->get_duration("durations.halfSecond", time_unit::MILLISECONDS));
+        REQUIRE(1 == conf->get_duration("durations.millis", time_unit::MILLISECONDS));
+        REQUIRE(1000 == conf->get_duration("durations.second", time_unit::MILLISECONDS));
+        REQUIRE(60 == conf->get_duration("durations.minute", time_unit::SECONDS));
+        REQUIRE(60 == conf->get_duration("durations.hour", time_unit::MINUTES));
+        REQUIRE(24 == conf->get_duration("durations.day", time_unit::HOURS));
+        REQUIRE(-4 == conf->get_duration("durations.minusSeconds", time_unit::SECONDS));
+        REQUIRE(43 == conf->get_duration("durations.secondWithFractional", time_unit::SECONDS));
+        REQUIRE(43200 == conf->get_duration("durations.secondWithFractional", time_unit::MILLISECONDS));
+        REQUIRE(9223372036854775807 == conf->get_duration("durations.largeNanos", time_unit::NANOSECONDS));
+        REQUIRE(-9223372036854775807 == conf->get_duration("durations.minusLargeNanos", time_unit::NANOSECONDS));
         // getting as a long truncates when casting to a larger value
-        REQUIRE(0 == conf->get_duration_as_long("durations.minute", time_unit::HOURS));
-        REQUIRE(9223372036 == conf->get_duration_as_long("durations.largeNanos", time_unit::SECONDS));
-        REQUIRE(153722867 == conf->get_duration_as_long("durations.largeNanos", time_unit::MINUTES));
-        REQUIRE(2562047 == conf->get_duration_as_long("durations.largeNanos", time_unit::HOURS));
-        REQUIRE(106751 == conf->get_duration_as_long("durations.largeNanos", time_unit::DAYS));
-
-        // Get as a double
-        REQUIRE(43.2 == conf->get_duration_as_double("durations.secondWithFractional", time_unit::SECONDS));
-        REQUIRE(43200.0 == conf->get_duration_as_double("durations.secondWithFractional", time_unit::MILLISECONDS));
-        REQUIRE(-4.0 == conf->get_duration_as_double("durations.minusSeconds", time_unit::SECONDS));
-        REQUIRE(0.5 == conf->get_duration_as_double("durations.halfSecond", time_unit::SECONDS));
-        REQUIRE(1000.0 == conf->get_duration_as_double("durations.second", time_unit::MILLISECONDS));
-        // getting as a double retains fractional part
-        REQUIRE((1.0 / 60.0) == conf->get_duration_as_double("durations.minute", time_unit::HOURS));
+        REQUIRE(0 == conf->get_duration("durations.minute", time_unit::HOURS));
+        REQUIRE(9223372036 == conf->get_duration("durations.largeNanos", time_unit::SECONDS));
+        REQUIRE(153722867 == conf->get_duration("durations.largeNanos", time_unit::MINUTES));
+        REQUIRE(2562047 == conf->get_duration("durations.largeNanos", time_unit::HOURS));
+        REQUIRE(106751 == conf->get_duration("durations.largeNanos", time_unit::DAYS));
     }
 
     SECTION("should throw an exception when overflow occurs", "[config]") {
-        REQUIRE_THROWS(conf->get_duration_as_long("durations.largeDays", time_unit::DAYS));
-        REQUIRE_THROWS(conf->get_duration_as_double("durations.largeDays", time_unit::NANOSECONDS));
-        REQUIRE_THROWS(conf->get_duration_as_long("durations.largeDays", time_unit::NANOSECONDS));
+        REQUIRE_THROWS(conf->get_duration("durations.largeDays", time_unit::DAYS));
+        REQUIRE_THROWS(conf->get_duration("durations.largeDays", time_unit::NANOSECONDS));
     }
 }


### PR DESCRIPTION
Returning parsed durations as doubles was not supported in the original Java. Due to overflow risks and the fact that it probably has very few use cases, this removes it form the C++ port.