### PR TITLE
(maint) Fix include file from file

### DIFF
--- a/lib/inc/internal/parseable.hpp
+++ b/lib/inc/internal/parseable.hpp
@@ -9,16 +9,13 @@
 namespace hocon {
 
     class config_document;
-    class parseable_file;
-    class parseable_string;
-    class parseable_not_found;
 
     class parseable : public config_parseable, public std::enable_shared_from_this<parseable> {
     public:
-        static parseable_file new_file(std::string input_file_path, config_parse_options options);
-        static parseable_string new_string(std::string s, config_parse_options options);
-        static parseable_not_found new_not_found(std::string what_not_found, std::string message,
-                                                 config_parse_options options);
+        static std::shared_ptr<parseable> new_file(std::string input_file_path, config_parse_options options);
+        static std::shared_ptr<parseable> new_string(std::string s, config_parse_options options);
+        static std::shared_ptr<parseable> new_not_found(std::string what_not_found, std::string message,
+                                                        config_parse_options options);
 
         static config_syntax syntax_from_extension(std::string name);
 
@@ -42,6 +39,11 @@ namespace hocon {
         virtual std::shared_ptr<config_parseable> relative_to(std::string file_name) const;
 
         std::string to_string() const;
+
+        // Disable copy constructors, as include_context assumes it can hold a reference to parseable.
+        parseable() = default;
+        parseable(parseable const&) = delete;
+        parseable& operator=(parseable const&) = delete;
 
     private:
         std::shared_ptr<config_document> parse_document(config_parse_options const& base_options) const;

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -40,7 +40,7 @@ namespace hocon {
 
     shared_config config::parse_string(string s, config_parse_options options)
     {
-        return parseable::new_string(move(s), move(options)).parse()->to_config();
+        return parseable::new_string(move(s), move(options))->parse()->to_config();
     }
 
     shared_config config::parse_string(string s)

--- a/lib/src/config_document_factory.cc
+++ b/lib/src/config_document_factory.cc
@@ -6,7 +6,7 @@ using namespace std;
 namespace hocon { namespace config_document_factory {
 
     shared_ptr<config_document> parse_file(string input_file_path, config_parse_options options) {
-        return parseable::new_file(move(input_file_path), move(options)).parse_config_document();
+        return parseable::new_file(move(input_file_path), move(options))->parse_config_document();
     }
 
     shared_ptr<config_document> parse_file(string input_file_path) {
@@ -14,7 +14,7 @@ namespace hocon { namespace config_document_factory {
     }
 
     shared_ptr<config_document> parse_string(string s, config_parse_options options) {
-        return parseable::new_string(move(s), move(options)).parse_config_document();
+        return parseable::new_string(move(s), move(options))->parse_config_document();
     }
 
     shared_ptr<config_document> parse_string(string s) {

--- a/lib/src/parseable.cc
+++ b/lib/src/parseable.cc
@@ -27,17 +27,17 @@ namespace hocon {
 
     const int parseable::MAX_INCLUDE_DEPTH = 50;
 
-    parseable_file parseable::new_file(std::string input_file_path, config_parse_options options) {
-        return parseable_file(move(input_file_path),  move(options));
+    shared_ptr<parseable> parseable::new_file(std::string input_file_path, config_parse_options options) {
+        return make_shared<parseable_file>(move(input_file_path),  move(options));
     }
 
-    parseable_string parseable::new_string(std::string s, config_parse_options options) {
-        return parseable_string(move(s), move(options));
+    shared_ptr<parseable> parseable::new_string(std::string s, config_parse_options options) {
+        return make_shared<parseable_string>(move(s), move(options));
     }
 
-    parseable_not_found parseable::new_not_found(std::string what_not_found, std::string message,
+    shared_ptr<parseable> parseable::new_not_found(std::string what_not_found, std::string message,
                                                  config_parse_options options) {
-        return parseable_not_found(move(what_not_found), move(message), move(options));
+        return make_shared<parseable_not_found>(move(what_not_found), move(message), move(options));
     }
 
     void parseable::post_construct(config_parse_options const& base_options) {

--- a/lib/src/simple_includer.cc
+++ b/lib/src/simple_includer.cc
@@ -144,8 +144,7 @@ namespace hocon {
         auto p = _context->relative_to(name);
         if (p == nullptr) {
             // avoid returning null
-            return make_shared<parseable_not_found>(
-                parseable::new_not_found(name, _("include was not found: '{1}'", name), move(parse_options)));
+            return parseable::new_not_found(name, _("include was not found: '{1}'", name), move(parse_options));
         } else {
             return p;
         }
@@ -153,8 +152,7 @@ namespace hocon {
 
     /** File name source */
     shared_parseable file_name_source::name_to_parseable(std::string name, config_parse_options parse_options) const {
-        return make_shared<parseable_file>(
-                parseable::new_file(move(name), move(parse_options)));
+        return parseable::new_file(move(name), move(parse_options));
     }
 
     /** Proxy */

--- a/lib/tests/conf_parser_test.cc
+++ b/lib/tests/conf_parser_test.cc
@@ -23,7 +23,7 @@ static shared_value parse_without_resolving(string s) {
     auto options = config_parse_options()
         .set_origin_description(make_shared<string>("test conf string"))
         .set_syntax(config_syntax::CONF);
-    return parseable::new_string(move(s), move(options)).parse_value();
+    return parseable::new_string(move(s), move(options))->parse_value();
 }
 
 static shared_value parse(string s) {
@@ -221,7 +221,7 @@ TEST_CASE("implied comma handling") {
         [&](string const &s) { return drop_curlies(s); }
     };
 
-    auto tested = 0;
+    auto tested = 0u;
     for (auto v : valids) {
         for (auto change : changes) {
             ++tested;
@@ -306,7 +306,7 @@ TEST_CASE("line numbers in errors (pending)", "[!shouldfail]") {
 TEST_CASE("to string for parseables") {
     // just be sure the to_string don't throw, to get test coverage
     auto options = config_parse_options();
-    parseable::new_file("foo", options).to_string();
+    parseable::new_file("foo", options)->to_string();
     // TODO: are other APIs needed?
 }
 

--- a/locales/cpp-hocon.pot
+++ b/locales/cpp-hocon.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: cpp-hocon 0.1.0\n"
+"Project-Id-Version: cpp-hocon 0.1.2\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -86,6 +86,38 @@ msgstr ""
 
 #: lib/src/config.cc
 msgid "List does not contain only configs."
+msgstr ""
+
+#: lib/src/config.cc
+msgid "Value at '{1}' was not a number or string."
+msgstr ""
+
+#: lib/src/config.cc
+msgid "Not a valid time_unit"
+msgstr ""
+
+#: lib/src/config.cc
+msgid "as_long: Overflow occurred during time conversion"
+msgstr ""
+
+#: lib/src/config.cc
+msgid "convert_long: Overflow occurred during time conversion"
+msgstr ""
+
+#: lib/src/config.cc
+msgid "convert_double: Overflow occurred during time conversion"
+msgstr ""
+
+#: lib/src/config.cc
+msgid "Could not parse time unit '{1}' (try ns, us, ms, s, m, h, or d)"
+msgstr ""
+
+#: lib/src/config.cc
+msgid "No number in duration value '{1}'"
+msgstr ""
+
+#: lib/src/config.cc
+msgid "Value '{1}' could not be converted to a number."
 msgstr ""
 
 #: lib/src/config.cc


### PR DESCRIPTION
Including a file from another file caused a crash because we were
creating a shared_ptr from a `parseable` value. The include context
assumes the parseable it's created from will will continue to exist,
meaning we can't copy parseables. Fix instances where we were creating
copies of parseables.

Fixes #75.