### PR TITLE
(maint) Allow unregistered options in boost::program_options interface

### DIFF
--- a/lib/inc/hocon/config_object.hpp
+++ b/lib/inc/hocon/config_object.hpp
@@ -45,6 +45,12 @@ namespace hocon {
          */
         virtual shared_value attempt_peek_with_partial_resolve(std::string const& key) const = 0;
 
+        /**
+         * Construct a list of keys in the _value map.
+         * Use a vector rather than set, because most of the time we just want to iterate over them.
+         */
+        virtual std::vector<std::string> key_set() const = 0;
+
         // map interface
         using iterator = std::unordered_map<std::string, shared_value>::const_iterator;
         virtual bool is_empty() const = 0;

--- a/lib/inc/hocon/program_options.hpp
+++ b/lib/inc/hocon/program_options.hpp
@@ -25,13 +25,19 @@ namespace hocon { namespace program_options {
 
             for (const auto& entry : cfg->entry_set()) {
                 po::option opt;
-
-                // TODO: enforce unregistered variable flag based on allow_unregistered setting
-
                 if (prefix.empty()) {
                     opt.string_key = entry.first;
                 } else {
                     opt.string_key = prefix + "." + entry.first;
+                }
+
+                // Skips options that are not registered in the description.
+                // This is different behavior than the built in program_options
+                // parsers, which pass the options along somehow. But for now
+                // it stops an exception from being thrown if there is an unknown
+                // item in the config file.
+                if (allow_unregistered && !desc.find_nothrow(opt.string_key, false)) {
+                    continue;
                 }
 
                 if (entry.second->value_type() == config_value::type::LIST) {

--- a/lib/inc/internal/values/config_delayed_merge_object.hpp
+++ b/lib/inc/internal/values/config_delayed_merge_object.hpp
@@ -18,6 +18,8 @@ namespace hocon {
 
         resolve_status get_resolve_status() const override { return resolve_status::UNRESOLVED; }
 
+        std::vector<std::string> key_set() const override { throw not_resolved(); }
+
         // map interface
         bool is_empty() const override { throw not_resolved(); }
         size_t size() const override { throw not_resolved(); }

--- a/lib/inc/internal/values/simple_config_object.hpp
+++ b/lib/inc/internal/values/simple_config_object.hpp
@@ -70,7 +70,7 @@ namespace hocon {
          * Construct a list of keys in the _value map.
          * Use a vector rather than set, because most of the time we just want to iterate over them.
          */
-        std::vector<std::string> key_set() const;
+        std::vector<std::string> key_set() const override;
 
         /**
          * Construct a list of the values from the provided map.

--- a/lib/tests/program_options.cc
+++ b/lib/tests/program_options.cc
@@ -31,14 +31,30 @@ TEST_CASE("arrays with only values are converted to boost::po") {
     REQUIRE(vm.count("foo") == 1);
 }
 
-TEST_CASE("arrays with objects are converted to paths in boost::po") {
+TEST_CASE("unregistered keys cause an exception when `allow_unregistered` is false") {
+    po::options_description opts("");
+    opts.add_options()("foo", "description");
+    po::variables_map vm;
+    REQUIRE_THROWS(po::store(parse_string(string("{foo : baz, bar : quux}"), opts, false), vm));
+}
+
+TEST_CASE("unregistered keys are ignored when `allow_unregistered` is true") {
+    po::options_description opts("");
+    opts.add_options()("foo", "description");
+    po::variables_map vm;
+    po::store(parse_string(string("{foo : baz, bar : quux}"), opts, true), vm);
+    REQUIRE(vm.count("foo") == 1);
+    REQUIRE(vm.count("bar") == 0);
+}
+
+TEST_CASE("arrays with objects cause an exception in boost::po") {
     po::options_description opts("");
     opts.add_options()("foo", "description");
     po::variables_map vm;
     REQUIRE_THROWS(po::store(parse_string(string("{foo : [ { bar : baz } ]}"), opts), vm));
 }
 
-TEST_CASE("Arrays mixed with objects produce both a field and a nested path in boost:po") {
+TEST_CASE("Arrays mixed with objects cause an exception in boost:po") {
     po::options_description opts("");
     opts.add_options()
          ("foo", po::value<vector<string>>(), "description");


### PR DESCRIPTION
Parsing more complicated HOCON structures (e.g. a list of HOCON objects) into boost::program_options does not work very well. This allows `program_options` to ignore keys not specified in the `options_description`, so that they can instead be handled specially.

The second commit adds a useful method to the public API of config_object, to make interacting with objects easier. This method already existed in the most common concrete implementation of the abstract class; this makes the method publicly accessible without casting.