### PR TITLE
(maint) Fix linking errors when building with Leatherman locale

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_definitions(-DLEATHERMAN_I18N)
 include(leatherman)
 
 # Add other dependencies
-find_package(Boost 1.54 REQUIRED COMPONENTS thread date_time chrono system program_options)
+find_package(Boost 1.54 REQUIRED COMPONENTS locale thread date_time chrono system program_options)
 
 # pthreads if you require the Boost.Thread component.
 find_package(Threads)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -30,6 +30,10 @@ target_link_libraries(lib${PROJECT_NAME}_test
     ${CMAKE_THREAD_LIBS_INIT}
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND BOOST_STATIC)
+    target_link_libraries(lib${PROJECT_NAME}_test iconv)
+endif()
+
 add_test(NAME "unit_tests" COMMAND lib${PROJECT_NAME}_test)
 
 configure_file (


### PR DESCRIPTION
When using leatherman::locale, it is necessary to also link against
boost::locale. On OSX, this further requires linking against the iconv
library.

@MikaelSmith would you mind looking over this and seeing if any of the added bits jump out at you as being definitely unnecessary. This went through enough iterations that I think some things may have been added that are actually irrelevant (and if you find any, I'd love to hear why they're not needed. Still trying to get the full picture on this stuff).