### PR TITLE
(maint) Remove step that mentions submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ M=MMMMMMMM++  FOR HUMANS   ++M8MMMMMM7M
 
 ## Pre-Build
 
-Initialize the Leatherman utility library submodule:
-
-    $ git submodule update --init
-
 Prepare the cmake release environment:
 
     $ mkdir release


### PR DESCRIPTION
Since leatherman is no longer a submodule for this project, this commit
removes that step from the readme since it's no longer required.