### PR TITLE
(maint) Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "issues": "https://tickets.puppet.com/browse/HC",
+  "people": [
+    {
+      "github": "MikaelSmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
+    },
+    {
+      "github": "branan",
+      "email": "branan@puppet.com",
+      "name": "Branan Riley"
+    },
+    {
+      "github": "Magisus",
+      "email": "maggie@puppet.com",
+      "name": "Maggie Dreyer"
+    },
+    {
+      "github": "whopper",
+      "email": "whopper@puppet.com",
+      "name": "Will Hopper"
+    },
+    {
+      "github": "HAIL9000",
+      "email": "hailee@puppet.com",
+      "name": "Hailee Kenney"
+    }
+  ]
+}


### PR DESCRIPTION
@branan @Magisus @HAIL9000 @whopper you all ok as maintainers?

I could also see adding overlap with https://github.com/puppetlabs/ruby-hocon/blob/master/MAINTAINERS /cc @cprice404 @waynr @jpinsonault 