### PR TITLE
(packaging) Bump version to 0.1.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.2.2)
 # Project Setup - modify to match project naming
 ## Source code for a simple command-line executable for a dynamic library will be generated from the project name.
 ## The command-line and library names will be based off the project name.
-project(cpp-hocon VERSION 0.1.2)
+project(cpp-hocon VERSION 0.1.5)
 
 string(MAKE_C_IDENTIFIER ${PROJECT_NAME} PROJECT_C_NAME)
 string(TOUPPER ${PROJECT_C_NAME} PROJECT_NAME_UPPER)


### PR DESCRIPTION
This version includes a fix to allow cpp-hocon to build with native clang on older OSX and FreeBSD platforms.