### PR TITLE
Resolve included files before including them

### DIFF
--- a/lib/src/simple_includer.cc
+++ b/lib/src/simple_includer.cc
@@ -58,7 +58,7 @@ namespace hocon {
     }
 
     shared_object simple_includer::include_file_without_fallback(shared_include_context context, std::string what) {
-        return config::parse_file_any_syntax(move(what), context->parse_options())->root();
+        return config::parse_file_any_syntax(move(what), context->parse_options())->resolve(config_resolve_options(true, true))->root();
     }
 
     config_parse_options simple_includer::clear_for_include(config_parse_options const& options) {


### PR DESCRIPTION
Fixes #95 : substitution inside the file should work without the full
path where they are included.