### PR TITLE
Fixed Self-Reference Substitution

### DIFF
--- a/lib/inc/internal/values/config_delayed_merge_object.hpp
+++ b/lib/inc/internal/values/config_delayed_merge_object.hpp
@@ -7,10 +7,12 @@
 
 namespace hocon {
 
-    class config_delayed_merge_object : public config_object, public replaceable_merge_stack {
+    class config_delayed_merge_object : public config_object, public unmergeable, public replaceable_merge_stack {
     public:
         config_delayed_merge_object(shared_origin origin, std::vector<shared_value> const& stack);
 
+        resolve_result<shared_value> resolve_substitutions(resolve_context const& context, resolve_source const& source) const override;
+        std::vector<shared_value> unmerged_values() const override;
         shared_value make_replacement(resolve_context const& context, int skipping) const override;
 
         shared_object with_value(path raw_path, shared_value value) const override;

--- a/lib/src/values/config_delayed_merge_object.cc
+++ b/lib/src/values/config_delayed_merge_object.cc
@@ -28,6 +28,15 @@ namespace hocon {
         }
     }
 
+    resolve_result<shared_value> config_delayed_merge_object::resolve_substitutions(resolve_context const& context,
+                                                                                    resolve_source const& source) const {
+        return config_delayed_merge::resolve_substitutions(dynamic_pointer_cast<const replaceable_merge_stack>(shared_from_this()), _stack, context, source);
+    }
+
+    vector<shared_value> config_delayed_merge_object::unmerged_values() const {
+        return _stack;
+    }
+
     shared_value config_delayed_merge_object::make_replacement(resolve_context const &context, int skipping) const {
         return config_delayed_merge::make_replacement(move(context), _stack, move(skipping));
     }

--- a/lib/src/values/config_delayed_merge_object.cc
+++ b/lib/src/values/config_delayed_merge_object.cc
@@ -1,6 +1,7 @@
 #include <internal/values/config_delayed_merge_object.hpp>
 #include <internal/values/config_delayed_merge.hpp>
 #include <internal/values/simple_config_list.hpp>
+#include <internal/resolve_result.hpp>
 #include <hocon/config_exception.hpp>
 #include <leatherman/locale/locale.hpp>
 

--- a/lib/src/values/simple_config_object.cc
+++ b/lib/src/values/simple_config_object.cc
@@ -29,7 +29,7 @@ namespace hocon {
                 if (key == *context.restrict_to_child().first()) {
                     auto remainder = context.restrict_to_child().remainder();
 
-                    if (remainder.empty()) {
+                    if (!remainder.empty()) {
                         auto result = context.restrict(remainder).resolve(v, source);
                         context = result.context.unrestricted().restrict(original_restrict);
                         return result.value;


### PR DESCRIPTION
According to documentation: https://github.com/lightbend/config/blob/master/HOCON.md#examples-of-self-referential-substitutions
```
A self-reference resolves to the value "below" even if it's part of a path expression. So for example:

foo : { a : { c : 1 } }
foo : ${foo.a}
foo : { a : 2 }

Here, ${foo.a} would refer to { c : 1 } rather than 2 and so the final merge would be { a : 2, c : 1 }.
Recall that for a field to be self-referential, it must have a substitution or value concatenation as its value. If a field has an object or array value, for example, then it is not self-referential even if there is a reference to the field itself inside that object or array.
```
But I'm getting crash in cases below:
```
"a": {"b": 27},
"obj": ${a}
# below is failing
"val": ${obj.b}

a = {aa = mama}
b = ${a} { bb = mia }
# below is failing
b.aa = mea
b.bb = culpa
```
Open Issue https://github.com/puppetlabs/cpp-hocon/issues/105