### PR TITLE
Added config resolver

### DIFF
--- a/lib/inc/hocon/config_resolve_options.hpp
+++ b/lib/inc/hocon/config_resolve_options.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "types.hpp"
 #include "export.h"
 
 namespace hocon {
@@ -35,7 +36,7 @@ namespace hocon {
          *
          * @return the default resolve options
          */
-        config_resolve_options(bool use_system_environment = true, bool allow_unresolved = false);
+        config_resolve_options(bool use_system_environment = true, bool allow_unresolved = false, shared_resolver resolver = NULL_RESOLVER);
 
         /**
          * Returns resolve options that disable any reference to "system" data
@@ -75,9 +76,48 @@ namespace hocon {
          */
         bool get_allow_unresolved() const;
 
+        /**
+         * Returns the resolver to use as a fallback if a substitution cannot be
+         * otherwise resolved. Never returns null. This method is mostly used by the
+         * config lib internally, not by applications.
+         *
+         * @param value
+         * @return the non-null fallback resolver
+         */
+        shared_resolver get_resolver() const;
+
+        /**
+         * Returns options where the given resolver used as a fallback if a
+         * reference cannot be otherwise resolved. This resolver will only be called
+         * after resolution has failed to substitute with a value from within the
+         * config itself and with any other resolvers that have been appended before
+         * this one. Multiple resolvers can be added using,
+         *
+         *  <pre>
+         *     ConfigResolveOptions options = ConfigResolveOptions.defaults()
+         *         .appendResolver(primary)
+         *         .appendResolver(secondary)
+         *         .appendResolver(tertiary);
+         * </pre>
+         *
+         * With this config unresolved references will first be resolved with the
+         * primary resolver, if that fails then the secondary, and finally if that
+         * also fails the tertiary.
+         *
+         * If all fallbacks fail to return a substitution "allow unresolved"
+         * determines whether resolution fails or continues.
+         *`
+         * @param value the resolver to fall back to
+         * @return options that use the given resolver as a fallback
+         */
+        config_resolve_options append_resolver(shared_resolver value);
+
     private:
         bool _use_system_environment;
         bool _allow_unresovled;
+        shared_resolver _resolver;
+
+        static const shared_resolver NULL_RESOLVER;
     };
 
 }  // namespace hocon

--- a/lib/inc/hocon/config_resolver.hpp
+++ b/lib/inc/hocon/config_resolver.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "types.hpp"
+#include "export.h"
+
+namespace hocon {
+
+    /**
+     * Implement this interface and provide an instance to
+     * {@link ConfigResolveOptions#appendResolver ConfigResolveOptions.appendResolver()}
+     * to provide custom behavior when unresolved substitutions are encountered
+     * during resolution.
+     * @since 1.3.2
+     */
+    class LIBCPP_HOCON_EXPORT config_resolver {
+    public:
+        /**
+         * Returns the value to substitute for the given unresolved path. To get the
+         * components of the path use {@link ConfigUtil#splitPath(String)}. If a
+         * non-null value is returned that value will be substituted, otherwise
+         * resolution will continue to consider the substitution as still
+         * unresolved.
+         *
+         * @param path the unresolved path
+         * @return the value to use as a substitution or null
+         */
+        shared_value lookup(const std::string &path) const
+        {
+          return nullptr;
+        }
+
+        /**
+         * Returns a new resolver that falls back to the given resolver if this
+         * one doesn't provide a substitution itself.
+         *
+         * It's important to handle the case where you already have the fallback
+         * with a "return this", i.e. this method should not create a new object if
+         * the fallback is the same one you already have. The same fallback may be
+         * added repeatedly.
+         *
+         * @param fallback the previous includer for chaining
+         * @return a new resolver
+         */
+        shared_resolver with_fallback(shared_resolver fallback) const
+        {
+          return fallback;
+        }
+
+    };
+}  // namespace hocon

--- a/lib/inc/hocon/config_resolver.hpp
+++ b/lib/inc/hocon/config_resolver.hpp
@@ -45,6 +45,5 @@ namespace hocon {
         {
           return fallback;
         }
-
     };
 }  // namespace hocon

--- a/lib/inc/hocon/types.hpp
+++ b/lib/inc/hocon/types.hpp
@@ -54,4 +54,8 @@ namespace hocon {
 
     class config_parseable;
     using shared_parseable = std::shared_ptr<const config_parseable>;
+
+    class config_resolver;
+    using shared_resolver = std::shared_ptr<const config_resolver>;
+
 }  // namespace hocon

--- a/lib/src/config_resolve_options.cc
+++ b/lib/src/config_resolve_options.cc
@@ -1,4 +1,6 @@
 #include <hocon/config_resolve_options.hpp>
+#include <hocon/config_resolver.hpp>
+#include <hocon/config_exception.hpp>
 
 using leatherman::locale::_;
 

--- a/lib/src/config_resolve_options.cc
+++ b/lib/src/config_resolve_options.cc
@@ -6,7 +6,7 @@ using leatherman::locale::_;
 
 namespace hocon {
 
-    const shared_resolver config_resolve_options::NULL_RESOLVER = make_shared<config_resolver>();
+    const shared_resolver config_resolve_options::NULL_RESOLVER = std::make_shared<config_resolver>();
 
     config_resolve_options::config_resolve_options(bool use_system_environment, bool allow_unresolved, shared_resolver resolver) :
         _use_system_environment(use_system_environment), _allow_unresovled(allow_unresolved), _resolver(resolver) { }

--- a/lib/src/config_resolve_options.cc
+++ b/lib/src/config_resolve_options.cc
@@ -2,11 +2,13 @@
 
 namespace hocon {
 
-    config_resolve_options::config_resolve_options(bool use_system_environment, bool allow_unresolved) :
-        _use_system_environment(use_system_environment), _allow_unresovled(allow_unresolved) { }
+    const shared_resolver config_resolve_options::NULL_RESOLVER = make_shared<config_resolver>();
+
+    config_resolve_options::config_resolve_options(bool use_system_environment, bool allow_unresolved, shared_resolver resolver) :
+        _use_system_environment(use_system_environment), _allow_unresovled(allow_unresolved), _resolver(resolver) { }
 
     config_resolve_options config_resolve_options::set_use_system_environment(bool value) const {
-        return config_resolve_options(value, _allow_unresovled);
+        return config_resolve_options(value, _allow_unresovled, _resolver);
     }
 
     bool config_resolve_options::get_use_system_environment() const {
@@ -14,11 +16,25 @@ namespace hocon {
     }
 
     config_resolve_options config_resolve_options::set_allow_unresolved(bool value) const {
-        return config_resolve_options(_use_system_environment, value);
+        return config_resolve_options(_use_system_environment, value, _resolver);
     }
 
     bool config_resolve_options::get_allow_unresolved() const {
         return _allow_unresovled;
+    }
+    shared_resolver config_resolve_options::get_resolver() const {
+        return _resolver;
+    }
+
+    config_resolve_options config_resolve_options::append_resolver(shared_resolver value) {
+        if (value == nullptr) {
+            throw bug_or_broken_exception(_("null resolver passed to append_resolver"));
+        } else if (value == _resolver) {
+            return *this;
+        } else {
+            return config_resolve_options(_use_system_environment, _allow_unresovled,
+                                            _resolver->with_fallback(value));
+        }
     }
 
 }  // namespace hocon

--- a/lib/src/config_resolve_options.cc
+++ b/lib/src/config_resolve_options.cc
@@ -1,5 +1,7 @@
 #include <hocon/config_resolve_options.hpp>
 
+using leatherman::locale::_;
+
 namespace hocon {
 
     const shared_resolver config_resolve_options::NULL_RESOLVER = make_shared<config_resolver>();

--- a/locales/cpp-hocon.pot
+++ b/locales/cpp-hocon.pot
@@ -343,6 +343,10 @@ msgstr ""
 msgid "Found a concatenation node in JSON"
 msgstr ""
 
+#: lib/src/config_resolve_options.cc
+msgid "null resolver passed to append_resolver"
+msgstr ""
+
 #: lib/src/default_transformer.cc
 msgid "No target value type specified"
 msgstr ""


### PR DESCRIPTION
As it was suggested here https://github.com/puppetlabs/cpp-hocon/issues/105
Comparing to https://github.com/lightbend/config/blob/master/config/src/main/java/com/typesafe/config/impl/ConfigReference.java#L93, it looks like the fallback code at https://github.com/puppetlabs/cpp-hocon/blob/master/lib/src/values/config_reference.cc#L61 wasn't implemented.
