### PR TITLE
(PA-2055) Disable unused warnings for boost::thread

### DIFF
--- a/lib/src/parseable.cc
+++ b/lib/src/parseable.cc
@@ -11,7 +11,10 @@
 #include <internal/config_document_parser.hpp>
 #include <internal/simple_include_context.hpp>
 #include <internal/config_parser.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #include <boost/thread/tss.hpp>
+#pragma GCC diagnostic pop
 #include <vector>
 #include <numeric>
 #include <leatherman/util/scope_exit.hpp>


### PR DESCRIPTION
With boost 1.67, boost/thread/tss.hpp introduces an unused symbol
warning in puppet-agent (https://github.com/puppetlabs/puppet-agent/pull/1482), halting a build with -Werror: disable that
warning temporarily around this file.