### PR TITLE
(PA-2055) Disable warnings for boost::variant

### DIFF
--- a/lib/inc/hocon/types.hpp
+++ b/lib/inc/hocon/types.hpp
@@ -3,7 +3,13 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+#if defined(__GNUC__) && __GNUC__ > 5
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
 #include "boost/variant.hpp"
+#pragma GCC diagnostic pop
 
 namespace hocon {
 


### PR DESCRIPTION
With boost 1.67, boost/variant.hpp introduces address and (in gcc 6+)
nonnull-compare warnings; Quiet these to allow successful builds with
-Werror. This supports https://github.com/puppetlabs/puppet-agent/pull/1482.