### PR TITLE
Unbreak build with Boost 1.72

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
     set(BOOST_COMPONENTS regex)
 endif()
 
-list(APPEND BOOST_COMPONENTS thread date_time chrono system program_options)
+list(APPEND BOOST_COMPONENTS thread date_time chrono filesystem system program_options)
 
 # Add other dependencies
 find_package(Boost 1.54 REQUIRED COMPONENTS ${BOOST_COMPONENTS})


### PR DESCRIPTION
Fixes #118. Boost.Filesystem [is not](http://www.boost.org/doc/libs/release/more/getting_started/unix-variants.html#header-only-libraries) a header-only library.