### PR TITLE
(build) Add missing headers

### DIFF
--- a/lib/src/path.cc
+++ b/lib/src/path.cc
@@ -4,6 +4,7 @@
 #include <internal/config_util.hpp>
 #include <internal/path_parser.hpp>
 #include <leatherman/locale/locale.hpp>
+#include <algorithm>
 
 // Mark string for translation (alias for leatherman::locale::format)
 using leatherman::locale::_;

--- a/lib/src/tokenizer.cc
+++ b/lib/src/tokenizer.cc
@@ -7,6 +7,7 @@
 #include <internal/values/config_string.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/nowide/convert.hpp>
 #include <leatherman/locale/locale.hpp>
 
 // Mark string for translation (alias for leatherman::locale::format)


### PR DESCRIPTION
This is needed to build with Boost 1.73.0, to fix these errors:

```
lib/src/path.cc: In static member function 'static bool hocon::path::has_funky_chars(const string&)':
lib/src/path.cc:176:25: error: 'find_if' was not declared in this scope; did you mean 'boost::mpl::find_if'?
  176 |         auto bad_char = find_if(s.begin(), s.end(), [] (char c) {
      |                         ^~~~~~~

lib/src/tokenizer.cc: In member function 'void hocon::token_iterator::pull_escape_sequence(std::string&, std::string&)':
lib/src/tokenizer.cc:310:42: error: 'narrow' is not a member of 'boost::nowide'
  310 |                 parsed += boost::nowide::narrow(buffer);
      |                                          ^~~~~~
```