### PR TITLE
(maint) Add regex backup if locales fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 include(leatherman)
 
 if(LEATHERMAN_USE_LOCALES)
-    set(BOOST_COMPONENTS locale)
+    set(BOOST_COMPONENTS locale regex)
 else()
     set(BOOST_COMPONENTS regex)
 endif()


### PR DESCRIPTION
In case the locales on the system fails(due to gconv, or something
else), leatherman will use boost::format and boost::regex, to create %N%
style formatting. 'regex' is only included in CMakeLists.txt if locales
are not enabled, but if they fail, 'regex' will be required

This PR adds 'regex' to BOOST_COMPONENTS regardless if leatherman uses
locales, as an extra check in case the locales are enabled but fail.