### PR TITLE
Fix example and segfault when adding a value to an empty document

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,23 @@ M=MMMMMMMM++  FOR HUMANS   ++M8MMMMMM7M
 To get started, [install it](#install), then to parse a file:
 ```
 #include <hocon/parser/config_document_factory.hpp>
-#include <leatherman/file_util/file.hpp>
+#include <fstream>
 
 using hocon::config_document_factory::parse_file;
-using leatherman::file_util::write_to_file;
 
 int main(int argc, char** argv) {
-    auto doc = parse_file("/path/to/file.conf");
-    doc.with_value_text("a.b", "42");
-    write_to_file(doc.render(), "/path/to/file.conf");
+    auto doc = parse_file("file.conf");
+    doc = doc->with_value_text("a", "42");
+
+    std::ofstream out("file.conf");
+    out << doc->render();
     return 0;
 }
+```
+
+If you build cpp-hocon with `-DBUILD_SHARED_LIBS=ON`, then the example can be built with
+```
+c++ example.cc -o example -std=c++11 -lcpp-hocon
 ```
 
 You can use `hocon::config_document_factory::parse_string` to parse a string. [config_document](lib/inc/hocon/parser/config_document.hpp) is used to modify a file while preserving all formatting. Use [config](lib/inc/hocon/config.hpp) to read from the config or if you don't care about preserving formatting.

--- a/lib/src/nodes/config_node_object.cc
+++ b/lib/src/nodes/config_node_object.cc
@@ -220,11 +220,11 @@ namespace hocon {
         }
 
         // Otherwise, construct the new setting
-        bool starts_with_brace = !children().empty();
-        if (auto single_token = dynamic_pointer_cast<const config_node_single_token>(children().front())) {
-            starts_with_brace = starts_with_brace && single_token->get_token() == tokens::open_curly_token();
-        } else {
-            starts_with_brace = false;
+        bool starts_with_brace = false;
+        if (!children().empty()) {
+            if (auto single_token = dynamic_pointer_cast<const config_node_single_token>(children().front())) {
+                starts_with_brace = single_token->get_token() == tokens::open_curly_token();
+            }
         }
 
         shared_node_list new_nodes;

--- a/lib/tests/config_node_test.cc
+++ b/lib/tests/config_node_test.cc
@@ -249,6 +249,14 @@ TEST_CASE("duplicates of a key are removed from a map", "[config-node]") {
     remove_duplicates_test(int_node(10), empty_map_node, empty_array);
 }
 
+void empty_initial_path_test(shared_node_value value) {
+    auto node = make_shared<config_node_object>(shared_node_list {});
+    REQUIRE("" == node->render());
+    auto new_node = node->set_value_on_path("foo", value);
+    string final_text = "foo : " + value->render();
+    REQUIRE(final_text == new_node->render());
+}
+
 void nonexistent_path_test(shared_node_value value) {
     auto node = make_shared<config_node_object>(
             shared_node_list { node_key_value_pair(node_key("bar"), int_node(15)) });
@@ -259,7 +267,7 @@ void nonexistent_path_test(shared_node_value value) {
 }
 
 TEST_CASE("creates non-existent paths", "[config-node]") {
-    nonexistent_path_test(int_node(10));
+    empty_initial_path_test(int_node(10));
     nonexistent_path_test(make_shared<config_node_object>(
             shared_node_list { open_brace_node(),
                                node_key_value_pair(node_key("foo"), double_node(3.14)),


### PR DESCRIPTION
Fixes the example and makes it clearer how to compile it.

Also fixes the segfault when adding a value to an empty document. If `children().empty()` is true, `children().front()` segfaults because there's nothing for it to return a ref to. Rework logic so we only attempt to check the first element if we know it exists.

Fixes #130.