### PR TITLE
(PA-5800) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/ci_checks.yaml
+++ b/.github/workflows/ci_checks.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: docker_pull_and_make
         uses: ./.github/actions/docker_pull_and_make
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: docker_pull_and_make
         uses: ./.github/actions/docker_pull_and_make
         with:


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.